### PR TITLE
Refactor experiment related stuff

### DIFF
--- a/src/components/ExperimentInput.tsx
+++ b/src/components/ExperimentInput.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+import {MaterialInput, MaterialSelect} from "./Components";
+import {ISelectOption, IExperiment, NEW_EXPERIMENT} from "./LeftPanelWidget";
+
+const regex: string = "^[a-zA-Z][-_a-zA-z0-9\\s]*$";
+const regexErrorMsg: string = "Experiment name may consist of alphanumeric " +
+                              "characters, '-', '_' and white spaces, and " +
+                              "must begin with letter.";
+
+interface IExperimentInput {
+    updateValue: Function;
+    options: IExperiment[];
+    selected: string;   // Experiment ID
+    value: string;      // Experiment Name
+    loading: boolean;
+}
+
+export const ExperimentInput: React.FunctionComponent<IExperimentInput> = (props) => {
+    const getName = (x: string) => {
+        const filtered = props.options.filter(o => o.id === x);
+        return (filtered.length === 0) ? '' : filtered[0].name;
+    };
+
+    const updateSelected = (selected: string, idx: number) => {
+        let value = (selected === NEW_EXPERIMENT.id) ?
+            ''
+            : getName(selected);
+        const experiment: IExperiment = {id: selected, name: value};
+        props.updateValue(experiment);
+    };
+
+    const updateValue = (value: string, idx: number) => {
+        const experiment: IExperiment = {name: value, id: NEW_EXPERIMENT.id}
+        props.updateValue(experiment);
+    };
+
+    const options: ISelectOption[] = props.options.map(o => {return {label: o.name, value: o.id}});
+
+    return <div>
+        <MaterialSelect
+            label={"Select experiment"}
+            values={options}
+            value={props.selected}
+            index={-1}
+            updateValue={updateSelected}
+            helperText={(props.loading ? "Loading..." : null)}
+        />
+        {(props.selected === NEW_EXPERIMENT.id) ?
+            <div>
+                <MaterialInput
+                    updateValue={updateValue}
+                    value={props.value}
+                    label={"Experiment Name"}
+                    regex={regex}
+                    regexErrorMsg={regexErrorMsg}
+                />
+            </div>
+            :null
+        }
+    </div>
+}


### PR DESCRIPTION
* Choose from current experiments or create a new one
* If experiment is not set in notebook's metadata, choose first
  experiment by default

* Define IExperiment: {id, name}
* Define ISelectOption: {label, value} and use it wherever possible
* Introduce the field state.metadata.experiment: IExperiment
* Keep state.metadata.experiment_name: string, for backwards
  compatibility. Prefer state.metadata.experiment
* Add state.experiments: IExperiment[]
* Add state.gettingExperiments boolean to show Loading message
* Fix experiment name regex

This requires Kale RPC kfp.list_experiments.

Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>