### PR TITLE
Extreme volume refactoring

### DIFF
--- a/src/components/Components.tsx
+++ b/src/components/Components.tsx
@@ -15,6 +15,7 @@ import OutlinedInput from "@material-ui/core/OutlinedInput";
 
 import { useDebouncedCallback } from 'use-debounce';
 import Switch from "react-switch";
+import {RokInput} from './RokInput';
 
 // https://codeburst.io/my-journey-to-make-styling-with-material-ui-right-6a44f7c68113
 const useStyles = makeStyles(() =>
@@ -54,9 +55,9 @@ const theme = createMuiTheme({
 });
 
 
-interface IMaterialInput {
+export interface IMaterialInput {
     updateValue: Function,
-    value: string,
+    value: string | number,
     regex?: string,
     regexErrorMsg?: string,
     inputIndex?: number,
@@ -70,7 +71,7 @@ interface IMaterialInput {
 
 export const MaterialInput: React.FunctionComponent<IMaterialInput> = (props) => {
 
-    const [value, setValue] = React.useState('');
+    const [value, setValue] = React.useState('' as any);
     const [error, updateError] = React.useState(false);
     const classes = useStyles({});
 
@@ -119,7 +120,8 @@ export const MaterialInput: React.FunctionComponent<IMaterialInput> = (props) =>
             InputLabelProps={{
                 classes: {
                     root: classes.label
-                }
+                },
+                shrink: value !== ''
             }}
             InputProps={inputProps}
             FormHelperTextProps={{
@@ -160,7 +162,8 @@ export const MaterialSelect: React.FunctionComponent<IMaterialSelect> = (props) 
             InputLabelProps={{
                 classes: {
                     root: classes.label
-                }
+                },
+                shrink: props.value !== ''
             }}
             InputProps={{
                 classes: {
@@ -353,6 +356,7 @@ interface IAnnotationInput {
     volumeIdx: number,
     annotationIdx: number,
     label: string,
+    cannotBeDeleted?: boolean,
 }
 
 export const AnnotationInput: React.FunctionComponent<IAnnotationInput> = (props) => {
@@ -374,29 +378,47 @@ export const AnnotationInput: React.FunctionComponent<IAnnotationInput> = (props
         props.updateValue({...props.annotation, value: value}, props.volumeIdx, props.annotationIdx)
     };
 
-    return <div className='toolbar'>
-        <MaterialInput
-            updateValue={updateKey}
-            value={props.annotation.key}
-            label={'Key'}
+    const valueField = (props.annotation.key === 'rok/origin') ?
+        <RokInput
+            updateValue={updateValue}
+            value={props.annotation.value}
+            label={'Rok URL'}
             inputIndex={props.volumeIdx}
+            annotationIdx={props.annotationIdx}
         />
-        <MaterialInput
+        :<MaterialInput
             updateValue={updateValue}
             value={props.annotation.value}
             label={'Value'}
             inputIndex={props.volumeIdx}
-        />
-        <div>
-            <button type="button"
-                className="minimal-toolbar-button"
-                title="Delete Annotation"
-                onClick={_ => props.deleteValue(props.volumeIdx, props.annotationIdx)}
-            >
-            <span
-                className="jp-CloseIcon jp-Icon jp-Icon-16"
-                style={{padding: 0, flex: "0 0 auto", marginRight: 0}}/>
-            </button>
+        />;
+
+    return <div className='toolbar'>
+        <div style={{marginRight: "10px", width: "50%"}}>
+            <MaterialInput
+                updateValue={updateKey}
+                value={props.annotation.key}
+                label={'Key'}
+                inputIndex={props.volumeIdx}
+                readOnly={props.cannotBeDeleted || false}
+            />
         </div>
+        <div style={{width: "50%"}}>
+            {valueField}
+        </div>
+        {(!props.cannotBeDeleted) ?
+            <div className="delete-button">
+                <Button
+                    variant="contained"
+                    size="small"
+                    title="Remove Annotation"
+                    onClick={_ => props.deleteValue(props.volumeIdx, props.annotationIdx)}
+                    style={{transform: 'scale(0.9)'}}
+                >
+                    <DeleteIcon />
+                </Button>
+            </div>
+            : null
+        }
     </div>
 };

--- a/src/components/LeftPanelWidget.tsx
+++ b/src/components/LeftPanelWidget.tsx
@@ -33,6 +33,19 @@ export const NEW_EXPERIMENT: IExperiment = {
     name: "+ New Experiment",
     id: "new"
 };
+const selectVolumeSizeTypes = [
+    {label: "Gi", value: "Gi", base: 1024 ** 3},
+    {label: "Mi", value: "Mi", base: 1024 ** 2},
+    {label: "Ki", value: "Ki", base: 1024 ** 1},
+    {label: "", value: "", base: 1024 ** 0},
+];
+
+const selectVolumeTypes = [
+    {label: "Create Empty Volume", value: 'new_pvc'},
+    {label: "Clone Notebook Volume", value: 'clone'},
+    {label: "Clone Existing Snapshot", value: 'snap'},
+    {label: "Use Existing Volume", value: 'pvc'},
+];
 
 interface IProps {
     tracker: INotebookTracker;
@@ -50,6 +63,9 @@ interface IState {
     activeCellIndex?: number;
     experiments: IExperiment[];
     gettingExperiments: boolean;
+    notebookVolumes: IVolumeMetadata[];
+    volumes: IVolumeMetadata[];
+    selectVolumeTypes: {label: string, value: string}[];
 }
 
 export interface IAnnotation {
@@ -63,12 +79,13 @@ export interface IVolumeMetadata {
     //  - pv: name of the PV
     //  - pvc: name of the pvc
     //  - new_pvc: new pvc with dynamic provisioning
+    //  - clone: clone a volume which is currently mounted to the Notebook Server
+    //  - snap: new_pvc from Rok Snapshot
     name: string,
     mount_point: string,
-    size?: string,
+    size?: number,
     size_type?: string,
-    annotations?: IAnnotation[],
-    // true if snapshot to be taken at the end of the pipeline
+    annotations: IAnnotation[],
     snapshot: boolean,
     snapshot_name?: string
 }
@@ -102,26 +119,30 @@ const DefaultState: IState = {
     activeCellIndex: 0,
     experiments: [],
     gettingExperiments: false,
+    notebookVolumes: [],
+    volumes: [],
+    selectVolumeTypes: selectVolumeTypes,
+};
+
+const DefaultEmptyVolume: IVolumeMetadata = {
+    type: 'new_pvc',
+    name: '',
+    mount_point: '',
+    annotations: [],
+    size: 1,
+    size_type: 'Gi',
+    snapshot: false,
+    snapshot_name: '',
+};
+
+const DefaultEmptyAnnotation: IAnnotation = {
+    key: '',
+    value: ''
 };
 
 export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
     // init state default values
     state = DefaultState;
-
-     DefaultEmptyVolume: IVolumeMetadata = {
-        type: 'new_pvc',
-        name: '',
-        mount_point: '',
-        annotations: [],
-        size: '1',
-        size_type: 'Gi',
-        snapshot: false
-    };
-
-    DefaultEmptyAnnotation: IAnnotation = {
-        key: '',
-        value: ''
-    };
 
     removeIdxFromArray = (index: number, arr: Array<any>): Array<any> => {return arr.slice(0, index).concat(arr.slice(index + 1, arr.length))};
     updateIdxInArray = (element: any, index: number, arr: Array<any>): Array<any> => {return arr.slice(0, index).concat([element]).concat(arr.slice(index + 1, arr.length))};
@@ -134,56 +155,141 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
     updateDockerImage = (name: string) => this.setState({metadata: {...this.state.metadata, docker_image: name}});
 
     // Volume managers
-    deleteVolume = (idx: number) => this.setState({metadata: {...this.state.metadata, volumes: this.removeIdxFromArray(idx, this.state.metadata.volumes)}});
-    addVolume = () => this.setState({metadata: {...this.state.metadata, volumes: [...this.state.metadata.volumes, this.DefaultEmptyVolume]}});
-    updateVolumeType = (type: string, idx: number) => this.setState({metadata: {...this.state.metadata, volumes: this.state.metadata.volumes.map((item, key) => {return (key === idx) ? {...this.state.metadata.volumes[idx], type: type}: item})}});
-    updateVolumeName = (name: string, idx: number) => this.setState({metadata: {...this.state.metadata, volumes: this.state.metadata.volumes.map((item, key) => {return (key === idx) ? {...this.state.metadata.volumes[idx], name: name}: item})}});
-    updateVolumeMountPoint = (mountPoint: string, idx: number) => this.setState({metadata: {...this.state.metadata, volumes: this.state.metadata.volumes.map((item, key) => {return (key === idx) ? {...this.state.metadata.volumes[idx], mount_point: mountPoint}: item})}});
-    updateVolumeSnapshot = (idx: number) => this.setState({metadata: {...this.state.metadata, volumes: this.state.metadata.volumes.map((item, key) => {return (key === idx) ? {...this.state.metadata.volumes[idx], snapshot: !this.state.metadata.volumes[idx].snapshot}: item})}});
-    updateVolumeSnapshotName = (name: string, idx: number) => this.setState({metadata: {...this.state.metadata, volumes: this.state.metadata.volumes.map((item, key) => {return (key === idx) ? {...this.state.metadata.volumes[idx], snapshot_name: name}: item})}});
-    updateVolumeSize = (size: string, idx: number) => this.setState({metadata: {...this.state.metadata, volumes: this.state.metadata.volumes.map((item, key) => {return (key === idx) ? {...this.state.metadata.volumes[idx], size: size}: item})}});
-    updateVolumeSizeType = (sizeType: string, idx: number) => this.setState({metadata: {...this.state.metadata, volumes: this.state.metadata.volumes.map((item, key) => {return (key === idx) ? {...this.state.metadata.volumes[idx], size_type: sizeType}: item})}});
-    addAnnotation = (idx: number) => this.setState({metadata: {
-        ...this.state.metadata,
-        volumes: this.state.metadata.volumes.map((item, key) => {
+    deleteVolume = (idx: number) => {
+        this.setState({
+            volumes: this.removeIdxFromArray(idx, this.state.volumes),
+            metadata: {...this.state.metadata, volumes: this.removeIdxFromArray(idx, this.state.metadata.volumes)}
+        });
+    };
+    addVolume = () => {
+        this.setState({
+            volumes: [...this.state.volumes, DefaultEmptyVolume],
+            metadata: {...this.state.metadata, volumes: [...this.state.metadata.volumes, DefaultEmptyVolume]}
+        });
+    };
+    updateVolumeType = (type: string, idx: number) => {
+        const kaleType: string = (type === "snap") ? "new_pvc" : type;
+        const annotations: IAnnotation[] = (type === "snap") ? [{key: "rok/origin", value: ""}]: [];
+        this.setState({
+            volumes: this.state.volumes.map((item, key) => {return (key === idx) ? {...item, type: type, annotations: annotations}: item}),
+            metadata: {...this.state.metadata, volumes: this.state.metadata.volumes.map((item, key) => {return (key === idx) ? {...item, type: kaleType, annotations: annotations}: item})}
+        });
+    };
+    updateVolumeName = (name: string, idx: number) => {
+        this.setState({
+            volumes: this.state.volumes.map((item, key) => {return (key === idx) ? {...item, name: name}: item}),
+            metadata: {...this.state.metadata, volumes: this.state.metadata.volumes.map((item, key) => {return (key === idx) ? {...item, name: name}: item})}
+        });
+    };
+    updateVolumeMountPoint = (mountPoint: string, idx: number) => {
+        let cloneVolume: IVolumeMetadata = null;
+        if (this.state.volumes[idx].type === "clone") {
+            cloneVolume = this.state.notebookVolumes.filter(v => v.mount_point === mountPoint)[0];
+        }
+        const updateItem = (item: IVolumeMetadata, key: number): IVolumeMetadata => {
+            if (key === idx) {
+                if (item.type === "clone") {
+                    return {...cloneVolume};
+                } else {
+                    return {...this.state.volumes[idx], mount_point: mountPoint};
+                }
+            } else {
+                return item;
+            }
+        };
+        this.setState({
+            volumes: this.state.volumes.map((item, key) => {return updateItem(item, key)}),
+            metadata: {
+                ...this.state.metadata,
+                volumes: this.state.metadata.volumes.map((item, key) => {return updateItem(item, key)})
+            }
+        });
+    };
+    updateVolumeSnapshot = (idx: number) => {
+        this.setState({
+            volumes: this.state.volumes.map((item, key) => {return (key === idx) ? {...this.state.volumes[idx], snapshot: !this.state.volumes[idx].snapshot}: item}),
+            metadata: {...this.state.metadata, volumes: this.state.metadata.volumes.map((item, key) => {return (key === idx) ? {...this.state.metadata.volumes[idx], snapshot: !this.state.metadata.volumes[idx].snapshot}: item})}
+        });
+    };
+    updateVolumeSnapshotName = (name: string, idx: number) => {
+        this.setState({
+            volumes: this.state.volumes.map((item, key) => {return (key === idx) ? {...this.state.volumes[idx], snapshot_name: name}: item}),
+            metadata: {...this.state.metadata, volumes: this.state.metadata.volumes.map((item, key) => {return (key === idx) ? {...this.state.metadata.volumes[idx], snapshot_name: name}: item})}
+        });
+    };
+    updateVolumeSize = (size: number, idx: number) => {
+        this.setState({
+            volumes: this.state.volumes.map((item, key) => {return (key === idx) ? {...this.state.volumes[idx], size: size}: item}),
+            metadata: {...this.state.metadata, volumes: this.state.metadata.volumes.map((item, key) => {return (key === idx) ? {...this.state.metadata.volumes[idx], size: size}: item})}
+        });
+    };
+    updateVolumeSizeType = (sizeType: string, idx: number) => {
+        this.setState({
+            volumes: this.state.volumes.map((item, key) => {return (key === idx) ? {...this.state.volumes[idx], size_type: sizeType}: item}),
+            metadata: {...this.state.metadata, volumes: this.state.metadata.volumes.map((item, key) => {return (key === idx) ? {...this.state.metadata.volumes[idx], size_type: sizeType}: item})}
+        });
+    };
+    addAnnotation = (idx: number) => {
+        const updateItem = (item: IVolumeMetadata, key: number) => {
             if (key === idx) {
                 return {
-                    ...this.state.metadata.volumes[idx],
-                    annotations: [...this.state.metadata.volumes[idx].annotations, this.DefaultEmptyAnnotation]
+                    ...item,
+                    annotations: [...item.annotations, DefaultEmptyAnnotation]
                 };
             } else {
                 return item;
             }
-        })
-    }});
+        };
+        this.setState({
+            volumes: this.state.volumes.map((item, key) => {return updateItem(item, key)}),
+            metadata: {
+                ...this.state.metadata,
+                volumes: this.state.metadata.volumes.map((item, key) => {return updateItem(item, key)})
+            }
+        });
+    };
     deleteAnnotation = (volumeIdx: number, annotationIdx: number) => {
-        this.setState({metadata: {
-            ...this.state.metadata,
-            volumes: this.state.metadata.volumes.map((item, key) => {
-                if (key === volumeIdx) {
-                    return {...item, annotations: this.removeIdxFromArray(annotationIdx, this.state.metadata.volumes[volumeIdx].annotations)};
-                } else {
-                    return item;
-                }
-            })
-        }});
+        const updateItem = (item: IVolumeMetadata, key: number) => {
+            if (key === volumeIdx) {
+                return {...item, annotations: this.removeIdxFromArray(annotationIdx, item.annotations)};
+            } else {
+                return item;
+            }
+        };
+        this.setState({
+            volumes: this.state.volumes.map((item, key) => {return updateItem(item, key)}),
+            metadata: {
+                ...this.state.metadata,
+                volumes: this.state.metadata.volumes.map((item, key) => {return updateItem(item, key)})
+            }
+        });
     };
     updateVolumeAnnotation = (annotation: {key: string, value: string}, volumeIdx: number, annotationIdx: number) => {
-        this.setState({metadata: {
-            ...this.state.metadata,
-            volumes: this.state.metadata.volumes.map((item, key) => {
-                if (key === volumeIdx) {
-                    return {
-                        ...item,
-                        annotations: this.updateIdxInArray(annotation, annotationIdx, this.state.metadata.volumes[volumeIdx].annotations)
-                    };
-                } else {
-                    return item;
-                }
-            })
-        }});
+        const updateItem = (item: IVolumeMetadata, key: number) => {
+            if (key === volumeIdx) {
+                return {
+                    ...item,
+                    annotations: this.updateIdxInArray(annotation, annotationIdx, item.annotations)
+                };
+            } else {
+                return item;
+            }
+        };
+        this.setState({
+            volumes: this.state.volumes.map((item, key) => {return updateItem(item, key)}),
+            metadata: {
+                ...this.state.metadata,
+                volumes: this.state.metadata.volumes.map((item, key) => {return updateItem(item, key)})
+            }
+        });
     };
-
+    getNotebookMountPoints = (): {label: string; value: string}[] => {
+        const mountPoints: {label: string, value: string}[] = [];
+        this.state.notebookVolumes.map((item) => {
+            mountPoints.push({label: item.mount_point, value: item.mount_point});
+        });
+        return mountPoints;
+    };
     activateRunDeployState = (type: string) => this.setState({runDeployment: true, deploymentType: type});
     changeDeployDebugMessage = () => this.setState({deployDebugMessage: !this.state.deployDebugMessage});
 
@@ -279,6 +385,8 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
             console.log(notebookMetadata);
 
             await this.getExperiments();
+            // Get information about volumes currently mounted on the notebook server
+            await this.getMountedVolumes();
 
             // if the key exists in the notebook's metadata
             if (notebookMetadata) {
@@ -299,62 +407,38 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
                     }
                     experiment_name = notebookMetadata['experiment_name'];
                 }
+                let metadataVolumes = (notebookMetadata['volumes'] || []).filter((v: IVolumeMetadata) => v.type !== 'clone');
+                let stateVolumes = metadataVolumes.map((volume: IVolumeMetadata) => {
+                    if (volume.type === 'new_pvc' && volume.annotations.length > 0 && volume.annotations[0].key === 'rok/origin') {
+                        return {...volume, type: 'snap'};
+                    }
+                    return volume;
+                });
+                if (stateVolumes.length === 0 && metadataVolumes.length === 0) {
+                    metadataVolumes = stateVolumes = this.state.notebookVolumes;
+                } else {
+                    metadataVolumes = metadataVolumes.concat(this.state.notebookVolumes);
+                    stateVolumes = stateVolumes.concat(this.state.notebookVolumes);
+                }
+
                 let metadata: IKaleNotebookMetadata = {
                     experiment: experiment,
                     experiment_name: experiment_name,
                     pipeline_name: notebookMetadata['pipeline_name'] || '',
                     pipeline_description: notebookMetadata['pipeline_description'] || '',
-                    docker_image: notebookMetadata['docker_image'] || '',
-                    volumes: notebookMetadata['volumes'] || [],
+                    docker_image: notebookMetadata['docker_image'] || DefaultState.metadata.docker_image,
+                    volumes: metadataVolumes,
                 };
-                this.setState({metadata: metadata, ...currentCell})
+                this.setState({
+                    volumes: stateVolumes,
+                    metadata: metadata, ...currentCell
+                });
             } else {
                 this.setState({metadata: DefaultState.metadata, ...currentCell})
             }
         } else {
             this.resetState();
         }
-    };
-
-    getExperiments = async () => {
-        this.setState({gettingExperiments: true});
-        let list_experiments: IExperiment[] = await this.executeRpc(this.state.activeNotebook, "kfp.list_experiments");
-        if (list_experiments) {
-            list_experiments.push(NEW_EXPERIMENT);
-        } else {
-            list_experiments = [NEW_EXPERIMENT];
-        }
-
-        // Fix experiment metadata
-        let experiment: IExperiment = null;
-        let selectedExperiments: IExperiment[] = list_experiments.filter(
-            e => (
-                e.id === this.state.metadata.experiment.id
-                || e.name === this.state.metadata.experiment.name
-                || e.name === this.state.metadata.experiment_name
-            )
-        );
-        if (selectedExperiments.length === 0 || selectedExperiments[0].id === NEW_EXPERIMENT.id) {
-            let name = list_experiments[0].name;
-            if (name === NEW_EXPERIMENT.name) {
-                name = (this.state.metadata.experiment.name !== '') ?
-                    this.state.metadata.experiment.name
-                    : this.state.metadata.experiment_name;
-            }
-            experiment = {...list_experiments[0], name: name};
-        } else {
-            experiment = selectedExperiments[0];
-        }
-
-        this.setState({
-            experiments: list_experiments,
-            gettingExperiments: false,
-            metadata: {
-                ...this.state.metadata,
-                experiment: experiment,
-                experiment_name: experiment.name,
-            },
-        });
     };
 
     runDeploymentCommand = async () => {
@@ -370,7 +454,7 @@ except Exception as e:
         _kale_output_message = [traceback.format_exc()]
     else:
         _kale_output_message = [str(e), 'To see full traceback activate the debugging option in Advanced Settings']
-`;
+        `;
         const initKaleCommand = `
     import traceback
     from kale.core import Kale as _Kale_Class
@@ -380,7 +464,7 @@ except Exception as e:
     _kale_generated_script_path = _kale_instance.generate_kfp_executable(_kale_pipeline_graph, _kale_pipeline_parameters)
     _kale_package_path = _kale_kfp_utils.compile_pipeline(_kale_generated_script_path, _kale_instance.pipeline_metadata['pipeline_name'])
     _kale_pipeline_name = _kale_instance.pipeline_metadata['pipeline_name']
-    `;
+        `;
         const uploadPipelineCommand = (overwrite: string = 'False') => `
     _kale_kfp_utils.upload_pipeline(
         pipeline_package_path=_kale_package_path,
@@ -388,7 +472,7 @@ except Exception as e:
         overwrite=${overwrite},
         host=_kale_instance.pipeline_metadata.get('kfp_host', None)
     )
-`;
+        `;
         const runPipelineCommand = `
     _kale_kfp_utils.run_pipeline(
         run_name=_kale_instance.pipeline_metadata['pipeline_name'] + '_run',
@@ -396,7 +480,7 @@ except Exception as e:
         pipeline_package_path=_kale_package_path,
         host=_kale_instance.pipeline_metadata.get('kfp_host', None)
     )
-`;
+        `;
 
         // CREATE PIPELINE
         const expr = {output: "_kale_output_message", pipeline_name: "_kale_pipeline_name"};
@@ -458,6 +542,67 @@ except Exception as e:
         this.setState({runDeployment: false});
     };
 
+    getExperiments = async () => {
+        this.setState({gettingExperiments: true});
+        let list_experiments: IExperiment[] = await this.executeRpc(this.state.activeNotebook, "kfp.list_experiments");
+        if (list_experiments) {
+            list_experiments.push(NEW_EXPERIMENT);
+        } else {
+            list_experiments = [NEW_EXPERIMENT];
+        }
+
+        // Fix experiment metadata
+        let experiment: IExperiment = null;
+        let selectedExperiments: IExperiment[] = list_experiments.filter(
+            e => (
+                e.id === this.state.metadata.experiment.id
+                || e.name === this.state.metadata.experiment.name
+                || e.name === this.state.metadata.experiment_name
+            )
+        );
+        if (selectedExperiments.length === 0 || selectedExperiments[0].id === NEW_EXPERIMENT.id) {
+            let name = list_experiments[0].name;
+            if (name === NEW_EXPERIMENT.name) {
+                name = (this.state.metadata.experiment.name !== '') ?
+                    this.state.metadata.experiment.name
+                    : this.state.metadata.experiment_name;
+            }
+            experiment = {...list_experiments[0], name: name};
+        } else {
+            experiment = selectedExperiments[0];
+        }
+
+        this.setState({
+            experiments: list_experiments,
+            gettingExperiments: false,
+            metadata: {
+                ...this.state.metadata,
+                experiment: experiment,
+                experiment_name: experiment.name,
+            },
+        });
+    };
+
+    getMountedVolumes = async () => {
+        let notebookVolumes: IVolumeMetadata[] = await this.executeRpc(this.state.activeNotebook, "nb.list_volumes");
+
+        if (notebookVolumes) {
+            notebookVolumes = notebookVolumes.map((volume) => {
+                const sizeGroup = selectVolumeSizeTypes.filter(s => volume.size >= s.base)[0];
+                volume.size = Math.ceil(volume.size / sizeGroup.base);
+                volume.size_type = sizeGroup.value;
+                volume.annotations = [];
+                return volume;
+            });
+            this.setState({
+                notebookVolumes: notebookVolumes,
+                selectVolumeTypes: selectVolumeTypes,
+            });
+        } else {
+            this.setState({selectVolumeTypes: selectVolumeTypes.filter(t => t.value !== 'clone')});
+        }
+    };
+
     render() {
 
         // FIXME: What about human-created Notebooks? Match name and old API as well
@@ -508,7 +653,7 @@ except Exception as e:
         />;
 
         const volsPanel = <VolumesPanel
-            volumes={this.state.metadata.volumes}
+            volumes={this.state.volumes}
             addVolume={this.addVolume}
             updateVolumeType={this.updateVolumeType}
             updateVolumeName={this.updateVolumeName}
@@ -521,6 +666,9 @@ except Exception as e:
             updateVolumeAnnotation={this.updateVolumeAnnotation}
             addAnnotation={this.addAnnotation}
             deleteAnnotation={this.deleteAnnotation}
+            notebookMountPoints={this.getNotebookMountPoints()}
+            selectVolumeSizeTypes={selectVolumeSizeTypes}
+            selectVolumeTypes={this.state.selectVolumeTypes}
         />;
 
         return (
@@ -534,38 +682,47 @@ except Exception as e:
                         </p>
                     </div>
 
-                    <div>
-                        <p className="kale-header">Pipeline Metadata</p>
+                    <div className="kale-component">
+                        <div>
+                            <p className="kale-header">Pipeline Metadata</p>
+                        </div>
+
+                        <div className={'input-container'}>
+                            {experiment_name_input}
+                            {pipeline_name_input}
+                            {pipeline_desc_input}
+                        </div>
                     </div>
 
-                    <div className={'input-container'}>
-                        {experiment_name_input}
-                        {pipeline_name_input}
-                        {pipeline_desc_input}
-                    </div>
 
                     {/*  CELLTAGS PANEL  */}
-                    <CellTags
-                        notebook={this.state.activeNotebook}
-                        activeCellIndex={this.state.activeCellIndex}
-                        activeCell={this.state.activeCell}
-                    />
+                    <div className="kale-component">
+                        <CellTags
+                            notebook={this.state.activeNotebook}
+                            activeCellIndex={this.state.activeCellIndex}
+                            activeCell={this.state.activeCell}
+                        />
+                    </div>
                     {/*  --------------  */}
 
                     {volsPanel}
 
-                    <CollapsablePanel
-                        title={"Advanced Settings"}
-                        dockerImageValue={this.state.metadata.docker_image}
-                        dockerChange={this.updateDockerImage}
-                        debug={this.state.deployDebugMessage}
-                        changeDebug={this.changeDeployDebugMessage}
-                    />
+                    <div className="kale-component">
+                        <CollapsablePanel
+                            title={"Advanced Settings"}
+                            dockerImageValue={this.state.metadata.docker_image}
+                            dockerChange={this.updateDockerImage}
+                            debug={this.state.deployDebugMessage}
+                            changeDebug={this.changeDeployDebugMessage}
+                        />
+                    </div>
 
-                    <SplitDeployButton
-                        running={this.state.runDeployment}
-                        handleClick={this.activateRunDeployState}
-                    />
+                    <div className="kale-component">
+                        <SplitDeployButton
+                            running={this.state.runDeployment}
+                            handleClick={this.activateRunDeployState}
+                        />
+                    </div>
                 </div>
 
             </div>

--- a/src/components/LeftPanelWidget.tsx
+++ b/src/components/LeftPanelWidget.tsx
@@ -68,6 +68,7 @@ interface IState {
     volumes?: IVolumeMetadata[];
     selectVolumeTypes: {label: string, value: string}[];
     useNotebookVolumes: boolean;
+    autosnapshot: boolean;
 }
 
 export interface IAnnotation {
@@ -125,6 +126,7 @@ const DefaultState: IState = {
     volumes: [],
     selectVolumeTypes: selectVolumeTypes,
     useNotebookVolumes: false,
+    autosnapshot: false,
 };
 
 const DefaultEmptyVolume: IVolumeMetadata = {
@@ -166,18 +168,25 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
             },
         })
     };
+    updateAutosnapshotSwitch = () => this.setState({autosnapshot: !this.state.autosnapshot});
 
     // Volume managers
     deleteVolume = (idx: number) => {
+        // If we delete the last volume, turn autosnapshot off
+        const autosnapshot = this.state.volumes.length === 1 ? false : this.state.autosnapshot;
         this.setState({
             volumes: this.removeIdxFromArray(idx, this.state.volumes),
-            metadata: {...this.state.metadata, volumes: this.removeIdxFromArray(idx, this.state.metadata.volumes)}
+            metadata: {...this.state.metadata, volumes: this.removeIdxFromArray(idx, this.state.metadata.volumes)},
+            autosnapshot: autosnapshot,
         });
     };
     addVolume = () => {
+        // If we add a volume to an empty list, turn autosnapshot on
+        const autosnapshot = this.state.volumes.length === 0 ? true : this.state.autosnapshot;
         this.setState({
             volumes: [...this.state.volumes, DefaultEmptyVolume],
-            metadata: {...this.state.metadata, volumes: [...this.state.metadata.volumes, DefaultEmptyVolume]}
+            metadata: {...this.state.metadata, volumes: [...this.state.metadata.volumes, DefaultEmptyVolume]},
+            autosnapshot: autosnapshot,
         });
     };
     updateVolumeType = (type: string, idx: number) => {
@@ -449,6 +458,7 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
                     volumes: stateVolumes,
                     metadata: metadata,
                     useNotebookVolumes: useNotebookVolumes,
+                    autosnapshot: stateVolumes.length > 0,
                     ...currentCell
                 });
             } else {
@@ -689,6 +699,8 @@ except Exception as e:
             selectVolumeTypes={this.state.selectVolumeTypes}
             useNotebookVolumes={this.state.useNotebookVolumes}
             updateVolumesSwitch={this.updateVolumesSwitch}
+            autosnapshot={this.state.autosnapshot}
+            updateAutosnapshotSwitch={this.updateAutosnapshotSwitch}
         />;
 
         return (

--- a/src/components/RokInput.tsx
+++ b/src/components/RokInput.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import Button from '@material-ui/core/Button';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import {IMaterialInput, MaterialInput} from './Components';
+import BrowseInRokBlue from '../icons/BrowseInRokBlue';
+
+
+interface IRokInput extends IMaterialInput {
+    annotationIdx: number;
+}
+
+let popupChooser: any;
+
+export const RokInput: React.FunctionComponent<IRokInput> = (props) => {
+    const {annotationIdx, ...rest} = props;
+
+    const state = React.useState({
+        chooserId: 'vol:' + rest.inputIndex + 'annotation:' + annotationIdx,
+        origin: window.location.origin,
+    });
+
+    const openFileChooser = () => {
+        const mode: string = 'file';
+        let create: boolean = false;
+        if (rest.label) {
+            const temp: string = rest.label as string;
+        }
+        const goTo: string = `${state[0].origin}/rok/buckets?mode=${mode}-chooser` +
+            `&create=${create}` +
+            `&chooser-id=${state[0].chooserId}`;
+
+        if (popupChooser && !popupChooser.closed) {
+            popupChooser.window.location.href = goTo;
+            popupChooser.focus();
+            return;
+        }
+
+        popupChooser = window.open(
+          `${state[0].origin}/rok/buckets?mode=${mode}-chooser` +
+            `&create=${create}` +
+            `&chooser-id=${state[0].chooserId}`,
+          'Chooser',
+          `height=500,width=600,menubar=0`,
+        );
+    };
+
+    React.useEffect(() => {
+        const handleMessage = (event: any) => {
+            if (event.origin !== state[0].origin) {
+                return;
+            }
+            if (
+                typeof event.data === 'object' &&
+                event.data.hasOwnProperty('chooser') &&
+                event.data.hasOwnProperty('chooserId') &&
+                event.data.chooserId === state[0].chooserId
+            ) {
+                rest.updateValue(event.data.chooser, rest.inputIndex);
+                popupChooser.close();
+            }
+        };
+
+        window.addEventListener('message', handleMessage);
+        return () => {
+            window.removeEventListener('message', handleMessage);
+        };
+    }, []);
+
+    const extraInputProps = {
+        endAdornment: (
+            <InputAdornment position='end'>
+                <Button
+                    color='secondary'
+                    id='chooseRokFileBtn'
+                    onClick={openFileChooser}
+                    style={{padding: '0px', minWidth: '0px'}}>
+                    <BrowseInRokBlue/>
+                </Button>
+            </InputAdornment>
+        ),
+    };
+
+    return (
+        <MaterialInput
+            extraInputProps={extraInputProps}
+            {...rest}
+        />
+    );
+};

--- a/src/components/VolumesPanel.tsx
+++ b/src/components/VolumesPanel.tsx
@@ -25,6 +25,8 @@ interface IProps {
     selectVolumeTypes: {label: string, value: string}[],
     useNotebookVolumes: boolean,
     updateVolumesSwitch: Function,
+    autosnapshot: boolean,
+    updateAutosnapshotSwitch: Function,
 }
 
 export class VolumesPanel extends React.Component<IProps, any> {
@@ -95,7 +97,7 @@ export class VolumesPanel extends React.Component<IProps, any> {
 
                             {(v.annotations && v.annotations.length > 0) ?
                                 v.annotations.map((a, a_idx) => {
-                                    return (<div key={"vol:" + idx + " annotation:" + a_idx}>
+                                    return (<div key={`vol-${idx}-annotation-${a_idx}`}>
                                         <AnnotationInput
                                             label={"Annotation"}
                                             volumeIdx={idx}
@@ -125,7 +127,7 @@ export class VolumesPanel extends React.Component<IProps, any> {
                         </div>: null;
 
                     return (
-                    <div className="input-container volume-container" key={idx}>
+                    <div className="input-container volume-container" key={`v-${idx}`}>
                         <div className="toolbar">
                             <MaterialSelect
                                 updateValue={this.props.updateVolumeType}
@@ -218,6 +220,46 @@ export class VolumesPanel extends React.Component<IProps, any> {
                     Add Volume
                 </Button>
             </div>;
+        const useNotebookVolumesSwitch =
+            <div className='toolbar input-container'>
+                <div className='switch-label'>Use this notebook's volumes</div>
+                <Switch
+                    checked={this.props.useNotebookVolumes}
+                    disabled={this.props.notebookMountPoints.length === 0}
+                    onChange={_ => this.props.updateVolumesSwitch()}
+                    onColor='#599EF0'
+                    onHandleColor='#477EF0'
+                    handleDiameter={18}
+                    uncheckedIcon={false}
+                    checkedIcon={false}
+                    boxShadow='0px 1px 5px rgba(0, 0, 0, 0.6)'
+                    activeBoxShadow='0px 0px 1px 7px rgba(0, 0, 0, 0.2)'
+                    height={10}
+                    width={20}
+                    className='skip-switch'
+                    id='nb-volumes-switch'
+                />
+            </div>;
+        const autoSnapshotSwitch =
+            <div className='toolbar input-container'>
+                <div className='switch-label'>Take Rok snapshots before each step</div>
+                <Switch
+                    checked={this.props.autosnapshot}
+                    disabled={this.props.volumes.length === 0}
+                    onChange={_ => this.props.updateAutosnapshotSwitch()}
+                    onColor='#599EF0'
+                    onHandleColor='#477EF0'
+                    handleDiameter={18}
+                    uncheckedIcon={false}
+                    checkedIcon={false}
+                    boxShadow='0px 1px 5px rgba(0, 0, 0, 0.6)'
+                    activeBoxShadow='0px 0px 1px 7px rgba(0, 0, 0, 0.2)'
+                    height={10}
+                    width={20}
+                    className='skip-switch'
+                    id='autosnapshot-switch'
+                />
+            </div>;
 
         return (
             <div className="kale-component">
@@ -225,36 +267,11 @@ export class VolumesPanel extends React.Component<IProps, any> {
                     <p className="kale-header">
                         Volumes
                     </p>
-                    <div className={"skip-switch-container"}>
-                        <button type="button"
-                                className="minimal-toolbar-button"
-                                title="Add Volume"
-                                onClick={_ => this.props.addVolume()}
-                        >
-                        </button>
-                    </div>
                 </div>
-
-                <div className='toolbar input-container' style={{borderBottom: 'inset', fontSize: 'initial'}}>
-                    <div className='switch-label'>Use this Notebook's Volumes</div>
-                    <Switch
-                        checked={this.props.useNotebookVolumes}
-                        onChange={_ => this.props.updateVolumesSwitch()}
-                        onColor='#599EF0'
-                        onHandleColor='#477EF0'
-                        handleDiameter={18}
-                        uncheckedIcon={false}
-                        checkedIcon={false}
-                        boxShadow='0px 1px 5px rgba(0, 0, 0, 0.6)'
-                        activeBoxShadow='0px 0px 1px 7px rgba(0, 0, 0, 0.2)'
-                        height={10}
-                        width={20}
-                        className='skip-switch'
-                        id='skip-switch'
-                    />
-                </div>
-                {this.props.useNotebookVolumes ? null : vols}
-                {this.props.useNotebookVolumes ? null : addButton}
+                {useNotebookVolumesSwitch}
+                {autoSnapshotSwitch}
+                {this.props.notebookMountPoints.length > 0 && this.props.useNotebookVolumes ? null : vols}
+                {this.props.notebookMountPoints.length > 0 && this.props.useNotebookVolumes ? null : addButton}
             </div>
         )
 

--- a/src/components/VolumesPanel.tsx
+++ b/src/components/VolumesPanel.tsx
@@ -23,6 +23,8 @@ interface IProps {
     notebookMountPoints: {label: string, value: string}[],
     selectVolumeSizeTypes: {label: string, value: string, base: number}[],
     selectVolumeTypes: {label: string, value: string}[],
+    useNotebookVolumes: boolean,
+    updateVolumesSwitch: Function,
 }
 
 export class VolumesPanel extends React.Component<IProps, any> {
@@ -201,8 +203,21 @@ export class VolumesPanel extends React.Component<IProps, any> {
                 }
 
             )}
-                </div>
+            </div>
         }
+        const addButton =
+            <div className="add-button">
+                <Button
+                    variant="contained"
+                    size="small"
+                    title="Add Volume"
+                    onClick={_ => this.props.addVolume()}
+                    style={{marginLeft: "10px"}}
+                >
+                    <AddIcon />
+                    Add Volume
+                </Button>
+            </div>;
 
         return (
             <div className="kale-component">
@@ -220,20 +235,26 @@ export class VolumesPanel extends React.Component<IProps, any> {
                     </div>
                 </div>
 
-                {vols}
-
-                <div className="add-button">
-                    <Button
-                        variant="contained"
-                        size="small"
-                        title="Add Volume"
-                        onClick={_ => this.props.addVolume()}
-                        style={{marginLeft: "10px"}}
-                    >
-                        <AddIcon />
-                        Add Volume
-                    </Button>
+                <div className='toolbar input-container' style={{borderBottom: 'inset', fontSize: 'initial'}}>
+                    <div className='switch-label'>Use this Notebook's Volumes</div>
+                    <Switch
+                        checked={this.props.useNotebookVolumes}
+                        onChange={_ => this.props.updateVolumesSwitch()}
+                        onColor='#599EF0'
+                        onHandleColor='#477EF0'
+                        handleDiameter={18}
+                        uncheckedIcon={false}
+                        checkedIcon={false}
+                        boxShadow='0px 1px 5px rgba(0, 0, 0, 0.6)'
+                        activeBoxShadow='0px 0px 1px 7px rgba(0, 0, 0, 0.2)'
+                        height={10}
+                        width={20}
+                        className='skip-switch'
+                        id='skip-switch'
+                    />
                 </div>
+                {this.props.useNotebookVolumes ? null : vols}
+                {this.props.useNotebookVolumes ? null : addButton}
             </div>
         )
 

--- a/src/icons/BrowseInRokBlue.tsx
+++ b/src/icons/BrowseInRokBlue.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+
+export default class BrowseInRokBLue extends React.Component<{ style?: React.CSSProperties }> {
+  public render(): JSX.Element {
+    return (
+      <svg
+        xmlns='http://www.w3.org/2000/svg'
+        xmlnsXlink='http://www.w3.org/1999/xlink'
+        style={this.props.style}
+        width='24'
+        height='24'
+        viewBox='0 0 24 24'
+      >
+        <defs>
+          <path
+            id='a'
+            d='M15.99 8.404A8 8 0 116.005.251a6.5 6.5 0 008.321 6.49l1.664 1.663z'
+          />
+        </defs>
+        <g fill='none' fillRule='evenodd' transform='translate(-3234 -2346)'>
+          <g transform='translate(3237 2352)'>
+            <mask id='b' fill='#fff'>
+              <use xlinkHref='#a' />
+            </mask>
+            <use fill='#4990E2' xlinkHref='#a' />
+            <path
+              fill='#FFF'
+              fillRule='nonzero'
+              d='M3 3v10h10V3H3zM2 2h12v12H2V2z'
+              mask='url(#b)'
+            />
+            <path
+              fill='#FFF'
+              fillRule='nonzero'
+              d='M6 10h4V6H6v4zM5 5h6v6H5V5z'
+              mask='url(#b)'
+            />
+          </g>
+          <path
+            fill='#4990E2'
+            fillRule='nonzero'
+            d='M3249.5 2355a2.5 2.5 0 100-5 2.5 2.5 0 000 5zm0 2a4.5 4.5 0 110-9 4.5 4.5 0 010 9z'
+          />
+          <path
+            fill='#4990E2'
+            fillRule='nonzero'
+            d='M0.793 2.207L4.328 5.743 5.743 4.328 2.207 0.793z'
+            transform='translate(3251 2354)'
+          />
+        </g>
+      </svg>
+    );
+  }
+}

--- a/style/index.css
+++ b/style/index.css
@@ -14,11 +14,15 @@
 | Components
 |----------------------------------------------------------------------------*/
 
+.kale-component {
+  padding: 5px 0px;
+}
+
 .kale-header {
   color: #477EF0;
   letter-spacing: .4px;
   /*margin-top: 8px;*/
-  padding: 20px 0 5px 12px;
+  padding: 5px;
   font-size: var(--jp-ui-font-size1);
   font-weight: 800;
   text-transform: uppercase;
@@ -26,7 +30,6 @@
 }
 
 .kale-header-switch {
-  padding: 20px 12px 0 12px;
   flex: 0 0 auto;
   flex-direction: row;
   justify-content: space-between;
@@ -150,6 +153,10 @@
   line-height: normal;
 }
 
+.volume-container {
+  border-bottom: inset;
+}
+
 /*https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container*/
 .toolbar {
   flex: 0 0 auto;
@@ -245,4 +252,38 @@
 
 .jp-Dialog-content {
   max-width: 75% !important;
+}
+
+.add-button {
+  padding: 5px;
+}
+
+.add-button button {
+  color: white;
+  background: rgb(65, 121, 244);
+}
+
+.add-button button:hover {
+  background: rgb(63, 108, 197);
+}
+
+.delete-button button {
+  padding: 5px 0px;
+  margin: 0px 10px;
+  min-width: 0px;
+  min-height: 0px;
+  width: 80%;
+  height: 80%;
+  border-radius: 50%;
+  color: rgb(255, 0, 25);
+  background: white;
+  box-shadow: none;
+}
+
+.delete-button button:hover {
+  color: rgb(189, 21, 35);
+}
+
+.delete-button svg {
+  transform: scale(0.8);
 }


### PR DESCRIPTION
* Introduce Clone Notebook Volume option
  This option is used to snapshot a volume currently mounted to the
  Notebook Server and feed the pipeline with a clone of that.
  Users select a volume using the mount point dropdown menu, which
  triggers an autofill. They, then, may modify volume's name or size.
* Introduce Clone Existing Snapshot option
  This option is similar to Create Empty Volume, but also has a fixed
  'rok/origin' annotation with a RokChooser button.
* Everytime the extension renders, get all Notebook Server volumes information
* Reorder volume name & mount point
* Make DefaultEmpty{Volume,Annotation} globals
* Initialize all state variables
* Integrate RokChooser in annotations when key is 'rok/origin'
* Use double volumes list for UX purposes
  * 'state.metadata.volumes' is the volumes list handled by Kale
  * 'state.volumes' may handle several volume types that Kale wouldn't
    need to. That way we can massively improve UX.
* Fix volume annotations bugs
* Add NB Volumes when opening a notebook
* Add 'Use this Notebook's Volumes' switch
* Add autosnapshot switch

Styling stuff
* Make Add* and Remove* buttons pretty
* Add kale-component css class and modify other classes
* Make space between size & size type and annotation key & value
* Add bottom border to volume entries