### PR TITLE
Feature: RPC Errors

### DIFF
--- a/src/components/LeftPanelWidget.tsx
+++ b/src/components/LeftPanelWidget.tsx
@@ -4,6 +4,7 @@ import {
     NotebookPanel
 } from "@jupyterlab/notebook";
 import NotebookUtils from "../utils/NotebookUtils";
+import { executeRpc } from "../utils/RPCUtils"
 import CellUtils from "../utils/CellUtils";
 import {
     CollapsablePanel,
@@ -420,7 +421,7 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
         // If that is the case, retry the RPC
         while (retryRpc) {
             try {
-                result = await NotebookUtils.executeRpc(this.props.kernel, func, args);
+                result = await executeRpc(this.props.kernel, func, args);
                 retryRpc = false;
             } catch (error) {
                 if (error.status !== 'aborted') {

--- a/src/utils/NotebookUtils.tsx
+++ b/src/utils/NotebookUtils.tsx
@@ -4,29 +4,6 @@ import { KernelMessage, Kernel } from "@jupyterlab/services";
 import { CommandRegistry } from "@phosphor/commands";
 import * as React from "react";
 
-
-enum RPC_CALL_STATUS {
-  OK = 0,
-  ImportError = 1,
-  ExecutionError = 2,
-  EncodingError = 3,
-}
-
-const getRpcStatusName = (code: number) => {
-  switch (code) {
-    case RPC_CALL_STATUS.OK:
-      return 'OK';
-    case RPC_CALL_STATUS.ImportError:
-      return 'ImportError';
-    case RPC_CALL_STATUS.ExecutionError:
-      return 'ExecutionError';
-    case RPC_CALL_STATUS.EncodingError:
-      return 'EncodingError';
-    default:
-      return 'UnknownError';
-  }
-};
-
 /** Contains utility functions for manipulating/handling notebooks in the application. */
 export default class NotebookUtilities {
   /**
@@ -334,79 +311,5 @@ export default class NotebookUtilities {
         allowStdIn,
         stopOnError
     )
-  }
-
-  /**
-   * Execute kale.rpc module functions
-   * Example: func_result = await this.executeRpc(kernel | notebookPanel, "rpc_submodule.func", {arg1, arg2})
-   *    where func_result is a JSON object
-   * @param func Function name to be executed
-   * @param kwargs Dictionary with arguments to be passed to the function
-   * @param env instance of Kernel or NotebookPanel
-   */
-  public static async executeRpc(env: Kernel.IKernelConnection | NotebookPanel,
-                                 func: string,
-                                 kwargs: any = {}) {
-    const cmd: string = `from kale.rpc.run import run as __kale_rpc_run\n`
-        + `__kale_rpc_result = __kale_rpc_run("${func}", '${window.btoa(JSON.stringify(kwargs))}')`;
-    console.log("Executing command: " + cmd);
-    const expressions = {result: "__kale_rpc_result"};
-    const output = (env instanceof NotebookPanel) ?
-      await this.sendKernelRequestFromNotebook(env, cmd, expressions) :
-      await this.sendKernelRequest(env, cmd, expressions);
-
-    const argsAsStr = Object.keys(kwargs).map(key => `${key}=${kwargs[key]}`).join(', ');
-    let msg = [
-      `Function Call: ${func}(${argsAsStr})`,
-    ];
-    // Log output
-    if (output.result.status !== "ok") {
-      const title = `Kernel failed during code execution`;
-      msg = msg.concat([
-        `Status: ${output.result.status}`,
-        `Output: ${JSON.stringify(output, null, 3)}`
-      ]);
-      console.error([title].concat(msg));
-      await this.showMessage(title, msg);
-      return null;
-    }
-
-    // console.log(msg.concat([output]));
-    const raw_data = output.result.data["text/plain"];
-    const json_data = window.atob(raw_data.substring(1, raw_data.length - 1));
-
-    // Validate response is a JSON
-    // If successful, run() method returns json.dumps() of any result
-    let parsedResult = undefined;
-    try {
-      parsedResult = JSON.parse(json_data);
-    } catch (error) {
-      const title = `Failed to parse response as JSON`;
-      msg = msg.concat([
-        `Error: ${JSON.stringify(error, null, 3)}`,
-        `Response data: ${json_data}`
-      ]);
-      console.error(msg);
-      await this.showMessage(title, msg);
-      return null;
-    }
-
-    if (parsedResult.status !== 0) {
-      const title = `An error has occured`;
-      msg = msg.concat([
-        `Status: ${parsedResult.status} (${getRpcStatusName(parsedResult.status)})`,
-        `Type: ${JSON.stringify(parsedResult.err_cls, null, 3)}`,
-        `Message: ${parsedResult.err_message}`
-      ]);
-      console.error(msg);
-      await this.showMessage(title, msg);
-      return null;
-    } else {
-      msg = msg.concat([
-        `Result: ${parsedResult}`
-      ]);
-      // console.log(msg);
-      return parsedResult.result;
-    }
   }
 }

--- a/src/utils/NotebookUtils.tsx
+++ b/src/utils/NotebookUtils.tsx
@@ -86,6 +86,25 @@ export default class NotebookUtilities {
   }
 
   /**
+   * Opens a pop-up dialog in JupyterLab with various information and button
+   * triggering reloading the page.
+   * @param title The title for the message popup
+   * @param msg The message
+   * @param buttonLabel The label to use for the button. Default is 'Refresh'
+   * @param buttonClassName The  classname to give to the 'refresh' button.
+   * @returns Promise<void> - A promise once the message is closed.
+   */
+  public static async showRefreshDialog(
+    title: string,
+    msg: string[],
+    buttonLabel: string = "Refresh",
+    buttonClassName: string = ""
+  ): Promise<void> {
+    await this.showMessage(title, msg, buttonLabel, buttonClassName);
+    location.reload();
+  }
+
+  /**
    * @description Creates a new JupyterLab notebook for use by the application
    * @param command The command registry
    * @returns Promise<NotebookPanel> - A promise containing the notebook panel object that was created (if successful).

--- a/src/utils/RPCUtils.tsx
+++ b/src/utils/RPCUtils.tsx
@@ -14,8 +14,11 @@ export interface IRPCError {
 enum RPC_CALL_STATUS {
     OK = 0,
     ImportError = 1,
-    ExecutionError = 2,
-    EncodingError = 3,
+    EncodingError = 2,
+    NotFound = 3,
+    InternalError = 4,
+    ServiceUnavailable = 5,
+    UnhandledError = 6,
 }
 
 const getRpcCodeName = (code: number) => {
@@ -24,12 +27,16 @@ const getRpcCodeName = (code: number) => {
             return 'OK';
         case RPC_CALL_STATUS.ImportError:
             return 'ImportError';
-        case RPC_CALL_STATUS.ExecutionError:
-            return 'ExecutionError';
         case RPC_CALL_STATUS.EncodingError:
             return 'EncodingError';
+        case RPC_CALL_STATUS.NotFound:
+            return 'NotFound';
+        case RPC_CALL_STATUS.InternalError:
+            return 'InternalError';
+        case RPC_CALL_STATUS.ServiceUnavailable:
+            return 'ServiceUnavailable';
         default:
-            return 'UnknownError';
+            return 'UnhandledError';
     }
 };
 
@@ -113,7 +120,7 @@ export const executeRpc = async (
         msg = msg.concat([
             `Code: ${parsedResult.code} (${getRpcCodeName(parsedResult.code)})`,
             `Message: ${parsedResult.err_message}`,
-            `Details: ${parsedResult.err_details || ''}`
+            `Details: ${parsedResult.err_details}`,
         ]);
         let error = {
             rpc: `${func}`,

--- a/src/utils/RPCUtils.tsx
+++ b/src/utils/RPCUtils.tsx
@@ -1,0 +1,102 @@
+import * as React from "react";
+import { NotebookPanel } from "@jupyterlab/notebook";
+import { Kernel } from "@jupyterlab/services";
+import NotebookUtils from "./NotebookUtils"
+
+enum RPC_CALL_STATUS {
+    OK = 0,
+    ImportError = 1,
+    ExecutionError = 2,
+    EncodingError = 3,
+}
+
+const getRpcCodeName = (code: number) => {
+    switch (code) {
+        case RPC_CALL_STATUS.OK:
+            return 'OK';
+        case RPC_CALL_STATUS.ImportError:
+            return 'ImportError';
+        case RPC_CALL_STATUS.ExecutionError:
+            return 'ExecutionError';
+        case RPC_CALL_STATUS.EncodingError:
+            return 'EncodingError';
+        default:
+            return 'UnknownError';
+    }
+};
+
+/**
+ * Execute kale.rpc module functions
+ * Example: func_result = await this.executeRpc(kernel | notebookPanel, "rpc_submodule.func", {arg1, arg2})
+ *    where func_result is a JSON object
+ * @param func Function name to be executed
+ * @param kwargs Dictionary with arguments to be passed to the function
+ * @param env instance of Kernel or NotebookPanel
+ */
+export const executeRpc = async (
+    env: Kernel.IKernelConnection | NotebookPanel,
+    func: string,
+    kwargs: any = {}
+) => {
+    const cmd: string = `from kale.rpc.run import run as __kale_rpc_run\n`
+        + `__kale_rpc_result = __kale_rpc_run("${func}", '${window.btoa(JSON.stringify(kwargs))}')`;
+    console.log("Executing command: " + cmd);
+    const expressions = {result: "__kale_rpc_result"};
+    const output = (env instanceof NotebookPanel) ?
+        await NotebookUtils.sendKernelRequestFromNotebook(env, cmd, expressions) :
+        await NotebookUtils.sendKernelRequest(env, cmd, expressions);
+
+    const argsAsStr = Object.keys(kwargs).map(key => `${key}=${kwargs[key]}`).join(', ');
+    let msg = [
+        `Function Call: ${func}(${argsAsStr})`,
+    ];
+    // Log output
+    if (output.result.status !== "ok") {
+        const title = `Kernel failed during code execution`;
+        msg = msg.concat([
+            `Status: ${output.result.status}`,
+            `Output: ${JSON.stringify(output, null, 3)}`
+        ]);
+        console.error([title].concat(msg));
+        await NotebookUtils.showMessage(title, msg);
+        return null;
+    }
+
+    // console.log(msg.concat([output]));
+    const raw_data = output.result.data["text/plain"];
+    const json_data = window.atob(raw_data.substring(1, raw_data.length - 1));
+
+    // Validate response is a JSON
+    // If successful, run() method returns json.dumps() of any result
+    let parsedResult = undefined;
+    try {
+        parsedResult = JSON.parse(json_data);
+    } catch (error) {
+        const title = `Failed to parse response as JSON`;
+        msg = msg.concat([
+            `Error: ${JSON.stringify(error, null, 3)}`,
+            `Response data: ${json_data}`
+        ]);
+        console.error(msg);
+        await NotebookUtils.showMessage(title, msg);
+        return null;
+    }
+
+    if (parsedResult.code !== 0) {
+        const title = `An error has occured`;
+        msg = msg.concat([
+            `Code: ${parsedResult.code} (${getRpcCodeName(parsedResult.code)})`,
+            `Type: ${JSON.stringify(parsedResult.err_cls, null, 3)}`,
+            `Message: ${parsedResult.err_message}`
+        ]);
+        console.error(msg);
+        await NotebookUtils.showMessage(title, msg);
+        return null;
+    } else {
+        msg = msg.concat([
+            `Result: ${parsedResult}`
+        ]);
+        // console.log(msg);
+        return parsedResult.result;
+    }
+}

--- a/src/utils/RPCUtils.tsx
+++ b/src/utils/RPCUtils.tsx
@@ -27,7 +27,7 @@ export interface IRPCError {
     err_cls: string;
 }
 
-enum RPC_CALL_STATUS {
+export enum RPC_CALL_STATUS {
     OK = 0,
     ImportError = 1,
     EncodingError = 2,

--- a/src/utils/RPCUtils.tsx
+++ b/src/utils/RPCUtils.tsx
@@ -3,6 +3,22 @@ import { NotebookPanel } from "@jupyterlab/notebook";
 import { Kernel } from "@jupyterlab/services";
 import NotebookUtils from "./NotebookUtils"
 
+export const globalUnhandledRejection = async (event: any) => {
+    // console.error(event.reason);
+    if (event.reason instanceof BaseError) {
+        console.error(event.reason.message, event.reason.error);
+        event.reason.showDialog().then();
+    } else {
+        showError(
+            'An unexpected error has occurred',
+            'JS',
+            `${event.reason.name}: ${event.reason.message}`,
+            'Please see the console for more information',
+            true
+        ).then();
+    }
+};
+
 export interface IRPCError {
     rpc: string;
     code: number;
@@ -198,7 +214,6 @@ export abstract class BaseError extends Error {
             this.stack = (new Error(message)).stack;
         }
         Object.setPrototypeOf(this, BaseError.prototype);
-        console.error(message, error);
     }
 
     public abstract async showDialog(refresh: boolean): Promise<void>

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -25,7 +25,7 @@ import '../style/index.css';
 
 import {KubeflowKaleLeftPanel} from './components/LeftPanelWidget'
 import NotebookUtils from "./utils/NotebookUtils";
-import { executeRpc } from "./utils/RPCUtils";
+import { executeRpc, globalUnhandledRejection } from "./utils/RPCUtils";
 import { Kernel } from "@jupyterlab/services";
 
 
@@ -62,6 +62,7 @@ async function activate(
     let widget: ReactWidget;
     const kernel: Kernel.IKernel = await NotebookUtils.createNewKernel();
     window.addEventListener("beforeunload", () => kernel.shutdown());
+    window.addEventListener('unhandledrejection', globalUnhandledRejection);
     // TODO: backend can become an Enum that indicates the type of
     //  env we are in (like Local Laptop, MiniKF, GCP, UI without Kale, ...)
     const backend = await getBackend(kernel);

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -25,6 +25,7 @@ import '../style/index.css';
 
 import {KubeflowKaleLeftPanel} from './components/LeftPanelWidget'
 import NotebookUtils from "./utils/NotebookUtils";
+import { executeRpc } from "./utils/RPCUtils";
 import { Kernel } from "@jupyterlab/services";
 
 
@@ -65,7 +66,7 @@ async function activate(
     //  env we are in (like Local Laptop, MiniKF, GCP, UI without Kale, ...)
     const backend = await getBackend(kernel);
     if (backend) {
-        await NotebookUtils.executeRpc(kernel, 'log.setup_logging');
+        await executeRpc(kernel, 'log.setup_logging');
     }
 
     /**
@@ -89,7 +90,7 @@ async function activate(
         if (backend) {
             // Check if NOTEBOOK_PATH env variable exists and if so load
             // that Notebook
-            const path = await NotebookUtils.executeRpc(kernel, "nb.resume_notebook_path");
+            const path = await executeRpc(kernel, "nb.resume_notebook_path");
             if (path) {
                 console.log("Resuming notebook " + path);
                 // open the notebook panel

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -25,7 +25,7 @@ import '../style/index.css';
 
 import {KubeflowKaleLeftPanel} from './components/LeftPanelWidget'
 import NotebookUtils from "./utils/NotebookUtils";
-import { executeRpc, globalUnhandledRejection } from "./utils/RPCUtils";
+import { executeRpc, globalUnhandledRejection, BaseError } from "./utils/RPCUtils";
 import { Kernel } from "@jupyterlab/services";
 
 
@@ -67,7 +67,12 @@ async function activate(
     //  env we are in (like Local Laptop, MiniKF, GCP, UI without Kale, ...)
     const backend = await getBackend(kernel);
     if (backend) {
-        await executeRpc(kernel, 'log.setup_logging');
+        try {
+            await executeRpc(kernel, 'log.setup_logging');
+        } catch (error) {
+            globalUnhandledRejection({reason: error});
+            throw error;
+        }
     }
 
     /**


### PR DESCRIPTION
* NotebookUtils: Add refresh dialog
* Move RPC stuff from NotebookUtils to RPCUtils
* RPCUtils: Define custom errors and throw them on RPC failure
* RPCUtils: Sync with error changes in backend
* Add global `UnhandledRejection` handler
* Use `try..catch` logic when executing RPCs