### PR TITLE
Enable RPC request context

### DIFF
--- a/src/components/LeftPanelWidget.tsx
+++ b/src/components/LeftPanelWidget.tsx
@@ -449,14 +449,17 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
         this.setState({activeCell: activeCell, activeCellIndex: notebook.activeCellIndex});
     };
 
-    executeRpc = async (func: string, args: any = {}) => {
+    executeRpc = async (func: string, args: any = {}, nb_path: string = null) => {
+        if (!nb_path && this.state.activeNotebook) {
+            nb_path = this.state.activeNotebook.context.path;
+        }
         let retryRpc = true;
         let result: any = null;
         // Kerned aborts the execution if busy
         // If that is the case, retry the RPC
         while (retryRpc) {
             try {
-                result = await executeRpc(this.props.kernel, func, args);
+                result = await executeRpc(this.props.kernel, func, args, {nb_path});
                 retryRpc = false;
             } catch (error) {
                 if ((error instanceof KernelError) && (error.error.status === 'aborted')) {
@@ -473,9 +476,9 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
     // This is our default behavior prior to this commit. This may probably
     // change in the future, setting custom logic for each RPC call. For
     // example, see getBaseImage().
-    executeRpcAndShowRPCError = async (func: string, args: any = {}) => {
+    executeRpcAndShowRPCError = async (func: string, args: any = {}, nb_path: string = null) => {
         try {
-            const result = await this.executeRpc(func, args);
+            const result = await this.executeRpc(func, args, nb_path);
             return result;
         } catch (error) {
             if (error instanceof RPCError) {

--- a/src/utils/RPCUtils.tsx
+++ b/src/utils/RPCUtils.tsx
@@ -25,6 +25,7 @@ export interface IRPCError {
     err_message: string;
     err_details: string;
     err_cls: string;
+    trans_id?: number;
 }
 
 export enum RPC_CALL_STATUS {
@@ -157,13 +158,11 @@ export const executeRpc = async (
             err_message: parsedResult.err_message,
             err_details: parsedResult.err_details,
             err_cls: parsedResult.err_cls,
+            trans_id: parsedResult.trans_id,
         };
         throw new RPCError(error);
     } else {
-        msg = msg.concat([
-            `Result: ${parsedResult}`
-        ]);
-        // console.log(msg);
+        // console.log(msg, parsedResult);
         return parsedResult.result;
     }
 }
@@ -176,6 +175,7 @@ export const showError = async (
     refresh: boolean = true,
     method: string = null,
     code: number = null,
+    trans_id: number = null,
 ): Promise<void> => {
     let msg: string[] = [
         `Browser: ${navigator ? navigator.userAgent : 'other'}`,
@@ -186,6 +186,9 @@ export const showError = async (
     }
     if (code) {
         msg.push(`Code: ${code} (${getRpcCodeName(code)})`)
+    }
+    if (trans_id) {
+        msg.push(`Transaction ID: ${trans_id}`)
     }
     msg.push(
         `Message: ${message}`,
@@ -211,6 +214,7 @@ export const showRpcError = async (
         refresh,
         error.rpc,
         error.code,
+        error.trans_id,
     );
 }
 

--- a/src/utils/RPCUtils.tsx
+++ b/src/utils/RPCUtils.tsx
@@ -64,21 +64,26 @@ export const rokErrorTooltip = (rokError: IRPCError) => {
     </React.Fragment>;
 };
 
+const serialize = (obj: any) => window.btoa(JSON.stringify(obj));
+const deserialize = (raw_data: string) => window.atob(raw_data.substring(1, raw_data.length - 1));
+
 /**
  * Execute kale.rpc module functions
  * Example: func_result = await this.executeRpc(kernel | notebookPanel, "rpc_submodule.func", {arg1, arg2})
  *    where func_result is a JSON object
  * @param func Function name to be executed
  * @param kwargs Dictionary with arguments to be passed to the function
+ * @param ctx Dictionary with the RPC context (e.g., nb_path)
  * @param env instance of Kernel or NotebookPanel
  */
 export const executeRpc = async (
     env: Kernel.IKernelConnection | NotebookPanel,
     func: string,
-    kwargs: any = {}
+    kwargs: any = {},
+    ctx: any = {}
 ) => {
     const cmd: string = `from kale.rpc.run import run as __kale_rpc_run\n`
-        + `__kale_rpc_result = __kale_rpc_run("${func}", '${window.btoa(JSON.stringify(kwargs))}')`;
+        + `__kale_rpc_result = __kale_rpc_run("${func}", '${serialize(kwargs)}', '${serialize(ctx)}')`;
     console.log("Executing command: " + cmd);
     const expressions = {result: "__kale_rpc_result"};
     let output: any = null;
@@ -117,7 +122,7 @@ export const executeRpc = async (
 
     // console.log(msg.concat([output]));
     const raw_data = output.result.data["text/plain"];
-    const json_data = window.atob(raw_data.substring(1, raw_data.length - 1));
+    const json_data = deserialize(raw_data);
 
     // Validate response is a JSON
     // If successful, run() method returns json.dumps() of any result


### PR DESCRIPTION
* Pass request context to RPC
  This context contains notebook's path (`nb_path`) if that exists.
  In the future, we may pass more context to the backend.
* Get TID (transaction id) from backend and show it in error dialogs
  TID is contained in log messages as [TID=...], so if some error occurs, `grep`ing the log file will come in handy.