### PR TITLE
Improve visualization of cell tags chips

### DIFF
--- a/src/components/cell-metadata/CellMetadataEditor.tsx
+++ b/src/components/cell-metadata/CellMetadataEditor.tsx
@@ -19,11 +19,17 @@ const CELL_TYPES = [
 ];
 
 export const RESERVED_CELL_NAMES = ['imports', 'functions', 'pipeline-parameters', 'skip'];
-const RESERVED_CELL_NAMES_HELP_TEXT: { [id: string]: string; } = {
+export const RESERVED_CELL_NAMES_HELP_TEXT: { [id: string]: string; } = {
     "imports": "The code in this cell will be pre-pended to every step of the pipeline.",
     "functions": "The code in this cell will be pre-pended to every step of the pipeline, after `imports`.",
     "pipeline-parameters": "The variables in this cell will be transformed into pipeline parameters, preserving the current values as defaults.",
     "skip": "This cell will be skipped and excluded from pipeline steps"
+};
+export const RESERVED_CELL_NAMES_CHIP_COLOR: { [id: string]: string; } = {
+    "skip": "a9a9a9",
+    "pipeline-parameters": "ee7a1a",
+    "imports": "a32626",
+    "functions": "a32626",
 };
 
 const STEP_NAME_ERROR_MSG = `Step name must consist of lower case alphanumeric characters or \'_\', and can not start with a digit.`

--- a/src/components/cell-metadata/ColorUtils.ts
+++ b/src/components/cell-metadata/ColorUtils.ts
@@ -1,3 +1,4 @@
+import {RESERVED_CELL_NAMES_CHIP_COLOR} from './CellMetadataEditor'
 
 const colorPool = [
     '#695181',
@@ -15,7 +16,7 @@ const colorPool = [
 export default class ColorUtils { 
 
     public static intToRGB(i: number) {
-            var c = (i & 0x00FFFFFF)
+            const c = (i & 0x00FFFFFF)
                 .toString(16)
                 .toUpperCase();
             return "00000".substring(0, 6 - c.length) + c;
@@ -40,6 +41,10 @@ export default class ColorUtils {
     public static getColor(value: string): string {
         if (!value) {
             return '';
+        }
+
+        if (value in RESERVED_CELL_NAMES_CHIP_COLOR){
+            return  RESERVED_CELL_NAMES_CHIP_COLOR[value];
         }
         return this.intToRGB(this.hashString(value))
     }

--- a/src/components/cell-metadata/InlineMetadata.tsx
+++ b/src/components/cell-metadata/InlineMetadata.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Chip, Tooltip } from '@material-ui/core';
 import ColorUtils from './ColorUtils';
-import { RESERVED_CELL_NAMES } from './CellMetadataEditor';
+import { RESERVED_CELL_NAMES, RESERVED_CELL_NAMES_HELP_TEXT } from './CellMetadataEditor';
 
 interface InlineMetadata {
     blockName: string;
@@ -22,9 +22,9 @@ export const InlineMetadata: React.FunctionComponent<InlineMetadata> = (props) =
     const [cellTypeClass, setCellTypeClass] = React.useState('');
 
     React.useEffect(() => {
-        updateClassName()
+        updateClassName();
         checkIfReservedName();
-        updateStyles()
+        updateStyles();
         updateDependencies();
         moveElement();
     }, [props.blockName, props.parentBlockName, props.prevBlockNames, props.cellElement]);
@@ -35,7 +35,7 @@ export const InlineMetadata: React.FunctionComponent<InlineMetadata> = (props) =
             const cellElement = props.cellElement;
             cellElement.classList.remove('kale-merged-cell');
 
-            const codeMirrorElem = cellElement.querySelector('.CodeMirror')
+            const codeMirrorElem = cellElement.querySelector('.CodeMirror');
             if (codeMirrorElem) {
                 codeMirrorElem.style.border = ''
             }
@@ -52,14 +52,14 @@ export const InlineMetadata: React.FunctionComponent<InlineMetadata> = (props) =
             c = c + ' hidden'
         }
         setClassName(c)
-    }
+    };
 
     const updateStyles = () => {
         const name = props.blockName || props.parentBlockName;
         if (!name) {
             return;
         }
-        const rgb = getColorFromName(name)
+        const rgb = getColorFromName(name);
         setColor(rgb);
 
         const cellElement = props.cellElement;
@@ -71,11 +71,11 @@ export const InlineMetadata: React.FunctionComponent<InlineMetadata> = (props) =
         if (props.parentBlockName) {
             cellElement.classList.add('kale-merged-cell');
         }
-    }
+    };
 
     const updateDependencies = () => {
         setDependencies(props.prevBlockNames.map((name, i) => {
-            const rgb = getColorFromName(name)
+            const rgb = getColorFromName(name);
             return (
                 <Tooltip
                     placement="top"
@@ -89,7 +89,7 @@ export const InlineMetadata: React.FunctionComponent<InlineMetadata> = (props) =
                     </div>
                 </Tooltip>)
         }))
-    }
+    };
 
     const checkIfReservedName = () => {
         if (RESERVED_CELL_NAMES.includes(props.blockName)) {
@@ -97,29 +97,47 @@ export const InlineMetadata: React.FunctionComponent<InlineMetadata> = (props) =
         } else {
             setCellTypeClass('')
         }
-    }
+    };
 
     const moveElement = () => {
         if ((props.blockName || props.parentBlockName) && wrapperRef && !wrapperRef.classList.contains('moved')) {
             wrapperRef.classList.add('moved');
             props.cellElement.insertAdjacentElement('afterbegin', wrapperRef);
         }
-    }
+    };
 
     const getColorFromName = (name: string) => {
         return ColorUtils.getColor(name);
-    }
+    };
 
     return (
         <div>
             <div className={className} ref={(elem) => {
                 if (elem) wrapperRef = elem;
             }} >
-                <Chip
-                    className={`kale-chip ${cellTypeClass}`}
-                    style={{ backgroundColor: `#${color}` }}
-                    key={props.blockName}
-                    label={props.blockName} />
+                {/* Add a `step: ` string before the Chip in case the chip belongs to a pipeline step*/}
+                {RESERVED_CELL_NAMES.includes(props.blockName) ?
+                    "" :
+                    <p style={{fontStyle: "italic", marginRight: "5px"}}>step:  </p>}
+
+                <Tooltip
+                    placement="top"
+                    key={props.blockName + 'tooltip'}
+                    title={RESERVED_CELL_NAMES.includes(props.blockName) ?
+                        RESERVED_CELL_NAMES_HELP_TEXT[props.blockName] :
+                        "This cell starts the pipeline step: " + props.blockName}>
+                    <Chip
+                        className={`kale-chip ${cellTypeClass}`}
+                        style={{ backgroundColor: `#${color}` }}
+                        key={props.blockName}
+                        label={props.blockName}
+                    />
+                </Tooltip>
+
+                {/* Add a `depends on: ` string before the deps dots in case there are some*/}
+                {dependencies.length > 0 ?
+                    <p style={{fontStyle: "italic", margin: "0 5px"}}>depends on:  </p> :
+                    ""}
                 {dependencies}
             </div>
         </div>

--- a/style/index.css
+++ b/style/index.css
@@ -449,7 +449,7 @@ a {
 }
 
 .kale-reserved-cell {
-  font-style: italic;
+  border-radius: 0 !important;
 }
 
 .kale-chip.MuiChip-root {


### PR DESCRIPTION
This PR changes how the cell tags chip are rendered:

- Reserved cell tags names chips are now squared
- Every Chip has a tooltip to display relevant information
- Dependencies dots are associated with a line tag.