### PR TITLE
Revamp cell metadata components

### DIFF
--- a/src/components/Components.tsx
+++ b/src/components/Components.tsx
@@ -53,10 +53,7 @@ const useStyles = makeStyles(() =>
       fontSize: 'var(--jp-ui-font-size2)',
     },
     input: {
-      borderRadius: 4,
-      position: 'relative',
       color: 'var(--jp-ui-font-color1)',
-      fontSize: 'var(--jp-ui-font-size2)',
     },
     focused: {},
     // notchedOutline: {
@@ -296,9 +293,7 @@ const useStylesSelectMulti = makeStyles(() =>
       display: 'flex',
       flexWrap: 'wrap',
     },
-    chip: {
-      margin: 2,
-    },
+    chip: {},
     multiSelectForm: {
       width: '100%',
     },
@@ -403,7 +398,7 @@ export const MaterialSelectMulti: React.FunctionComponent<IMaterialSelectMultipl
                     }}
                     key={value}
                     label={value}
-                    className={`kale-chip ${classes.chip}`}
+                    className={`kale-chip kale-chip-select ${classes.chip}`}
                   />
                 );
               })}

--- a/src/components/cell-metadata/CellMetadataContext.ts
+++ b/src/components/cell-metadata/CellMetadataContext.ts
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+export const CellMetadataContext = React.createContext({
+  isEditorVisible: false,
+  activeCellIndex: -1,
+  onEditorVisibilityChange: (isEditorVisible: boolean) => {},
+});

--- a/src/components/cell-metadata/CellMetadataEditor.tsx
+++ b/src/components/cell-metadata/CellMetadataEditor.tsx
@@ -22,10 +22,10 @@ import {
   MaterialSelectMulti,
 } from '../Components';
 import CellUtils from '../../utils/CellUtils';
-import { ICellModel, isCodeCellModel, CellModel } from '@jupyterlab/cells';
-import EditIcon from '@material-ui/icons/Edit';
+import { isCodeCellModel } from '@jupyterlab/cells';
 import CloseIcon from '@material-ui/icons/Close';
 import ColorUtils from './ColorUtils';
+import { CellMetadataContext } from './CellMetadataContext';
 
 const KUBEFLOW_CELL_METADATA_KEY = 'kubeflow_cell';
 
@@ -70,58 +70,45 @@ export const RESERVED_CELL_NAMES_CHIP_COLOR: { [id: string]: string } = {
 const STEP_NAME_ERROR_MSG = `Step name must consist of lower case alphanumeric
  characters or \'_\', and can not start with a digit.`;
 
-interface IProps {
+export interface IProps {
   notebook: NotebookPanel;
-  activeCellIndex: number;
-  cellModel: ICellModel;
   stepName?: string;
-  cellMetadata?: any;
-  parentBlockName?: string;
+  stepDependencies: string[];
 }
 
+// this stores the name of a block and its color (form the name hash)
+type BlockDependencyChoice = { value: string; color: string };
 interface IState {
-  showEditor: boolean;
-  currentActiveCellMetadata: IKaleCellMetadata;
-  allBlocks?: string[];
-  prevBlockName?: string;
-  wrapperClass?: string;
+  // used to store the closest preceding block name. Used in case the current
+  // block name is empty, to suggest merging to the previous one.
+  previousBlockName?: string;
   stepNameErrorMsg?: string;
+  // a list of blocks that the current step can be dependent on.
+  blockDependenciesChoices?: BlockDependencyChoice[];
 }
-
-interface IKaleCellMetadata {
-  blockName: string;
-  prevBlockNames?: string[];
-}
-
-const DefaultCellMetadata: IKaleCellMetadata = {
-  blockName: '',
-  prevBlockNames: [],
-};
 
 const DefaultState: IState = {
-  showEditor: false,
-  allBlocks: [],
-  currentActiveCellMetadata: DefaultCellMetadata,
-  prevBlockName: null,
-  wrapperClass: '',
+  previousBlockName: null,
   stepNameErrorMsg: STEP_NAME_ERROR_MSG,
+  blockDependenciesChoices: [],
 };
 
+/**
+ * Component that allow to edit the Kale cell tags of a notebook cell.
+ */
 export class CellMetadataEditor extends React.Component<IProps, IState> {
-  state = DefaultState;
+  static contextType = CellMetadataContext;
   editorRef: React.RefObject<HTMLDivElement> = null;
 
   constructor(props: IProps) {
     super(props);
+    // We use this element referene in order to move it inside Notebooks's cell
+    // element.
     this.editorRef = React.createRef();
-  }
-
-  componentDidMount() {
-    if (this.props.cellModel && isCodeCellModel(this.props.cellModel)) {
-      this.updateClassName();
-      this.readAndShowMetadata();
-      this.moveEditor();
-    }
+    this.state = DefaultState;
+    this.updateCurrentBlockName = this.updateCurrentBlockName.bind(this);
+    this.updateCurrentCellType = this.updateCurrentCellType.bind(this);
+    this.updatePrevBlocksNames = this.updatePrevBlocksNames.bind(this);
   }
 
   componentWillUnmount() {
@@ -131,78 +118,123 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
     }
   }
 
-  updateCurrentCellType = async (value: string) => {
+  updateCurrentCellType = (value: string) => {
     if (RESERVED_CELL_NAMES.includes(value)) {
-      await this.updateCurrentBlockName(value);
+      this.updateCurrentBlockName(value);
     } else {
-      await this.updateCurrentBlockName('');
-      await this.updatePrevBlocksNames([]);
-      await this.setState({
-        prevBlockName: this.getPreviousBlock(
-          this.props.notebook.content,
-          this.props.activeCellIndex,
-        ),
-      });
+      this.resetCell();
     }
   };
 
+  resetCell() {
+    const value = '';
+    const previousBlocks: string[] = [];
+
+    const oldBlockName: string = this.props.stepName;
+    let cellMedatada = {
+      prevBlockNames: previousBlocks,
+      blockName: value,
+    };
+    this.setKaleCellTags(
+      this.props.notebook,
+      this.context.activeCellIndex,
+      KUBEFLOW_CELL_METADATA_KEY,
+      cellMedatada,
+      false,
+    ).then(oldValue => {
+      this.updateKaleCellsTags(this.props.notebook, oldBlockName, value);
+    });
+  }
+
+  isEqual(a: any, b: any): boolean {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+
+  /**
+   * When the activeCellIndex of the editor changes, the editor needs to be
+   * moved to the correct position.
+   */
   moveEditor() {
+    if (!this.props.notebook) {
+      return;
+    }
+    // get the HTML element corresponding to the current active cell
     const metadataWrapper = this.props.notebook.content.node.childNodes[
-      this.props.activeCellIndex
+      this.context.activeCellIndex
     ] as HTMLElement;
     const editor = this.editorRef.current;
-    if (metadataWrapper && editor && !editor.classList.contains('moved')) {
-      editor.classList.add('moved');
-      metadataWrapper.insertAdjacentElement('afterbegin', editor);
+    const inlineElement = metadataWrapper.querySelector(
+      '.kale-inline-cell-metadata',
+    );
+    const elem = metadataWrapper.querySelector('.moved');
+    if (elem && !elem.querySelector('.kale-metadata-editor-wrapper')) {
+      elem.insertBefore(editor, inlineElement.nextSibling);
     }
   }
 
-  componentDidUpdate = async (
-    prevProps: Readonly<IProps>,
-    prevState: Readonly<IState>,
-  ) => {
-    try {
-      if (
-        prevProps.cellMetadata.prevBlockNames.join() !==
-        this.props.cellMetadata.prevBlockNames.join()
-      ) {
-        this.updateClassName();
-        this.readAndShowMetadata();
+  componentDidUpdate(prevProps: Readonly<IProps>, prevState: Readonly<IState>) {
+    this.hideEditorIfNotCodeCell();
+    this.moveEditor();
+    this.setState(this.updateBlockDependenciesChoices);
+    this.setState(this.updatePreviousStepName);
+  }
+
+  hideEditorIfNotCodeCell() {
+    if (this.props.notebook && !this.props.notebook.isDisposed) {
+      const cellModel = this.props.notebook.model.cells.get(
+        this.context.activeCellIndex,
+      );
+      if (!isCodeCellModel(cellModel) && this.context.isEditorVisible) {
+        this.closeEditor();
       }
-    } catch (error) {
-      console.error(error);
     }
-  };
+  }
 
-  updateClassName = () => {
-    let c = `kale-metadata-editor-wrapper kale-metadata-editor-wrapper-${this.props.activeCellIndex}`;
-    this.setState({ wrapperClass: c });
-  };
+  /**
+   * Scan the notebook for all block tags and get them all, excluded the current
+   * one (and the reserved cell tags) The value `previousBlockChoices` is used
+   * by the dependencies select option to select the current step's
+   * dependencies.
+   */
+  updateBlockDependenciesChoices(
+    state: Readonly<IState>,
+    props: Readonly<IProps>,
+  ): IState {
+    if (!props.notebook) {
+      return null;
+    }
+    const allBlocks = this.getAllBlocks(props.notebook.content);
+    const dependencyChoices: BlockDependencyChoice[] = allBlocks
+      // remove all reserved names and current step name
+      .filter(
+        el => !RESERVED_CELL_NAMES.includes(el) && !(el === props.stepName),
+      )
+      .map(name => ({ value: name, color: `#${this.getColor(name)}` }));
 
-  readAndShowMetadata = () => {
-    const allBlocks = this.getAllBlocks(this.props.notebook.content);
+    if (this.isEqual(state.blockDependenciesChoices, dependencyChoices)) {
+      return null;
+    }
+    return { blockDependenciesChoices: dependencyChoices };
+  }
+
+  updatePreviousStepName(
+    state: Readonly<IState>,
+    props: Readonly<IProps>,
+  ): IState {
+    if (!props.notebook) {
+      return null;
+    }
     const prevBlockName = this.getPreviousBlock(
-      this.props.notebook.content,
-      this.props.activeCellIndex,
+      props.notebook.content,
+      this.context.activeCellIndex,
     );
-
-    if (this.props.cellMetadata) {
-      this.setState({
-        allBlocks: allBlocks,
-        prevBlockName: prevBlockName,
-        currentActiveCellMetadata: {
-          blockName: this.props.cellMetadata.blockName || '',
-          prevBlockNames: this.props.cellMetadata.prevBlockNames || [],
-        },
-      });
-    } else {
-      this.setState({
-        allBlocks: allBlocks,
-        prevBlockName: prevBlockName,
-        currentActiveCellMetadata: DefaultCellMetadata,
-      });
+    if (prevBlockName === this.state.previousBlockName) {
+      return null;
     }
-  };
+    return {
+      previousBlockName: prevBlockName,
+    };
+  }
 
   getPreviousBlock = (notebook: Notebook, current: number): string => {
     for (let i = current - 1; i >= 0; i--) {
@@ -220,6 +252,9 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
   };
 
   getAllBlocks = (notebook: Notebook): string[] => {
+    if (!notebook.model) {
+      return [];
+    }
     let blocks = new Set<string>();
     for (const idx of Array(notebook.model.cells.length).keys()) {
       let mt = this.getKaleCellTags(notebook, idx, KUBEFLOW_CELL_METADATA_KEY);
@@ -230,32 +265,39 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
     return Array.from(blocks);
   };
 
-  updateCurrentBlockName = async (value: string) => {
-    const oldBlockName: string = this.state.currentActiveCellMetadata.blockName;
+  /**
+   * Even handler of the block name input text field
+   */
+  updateCurrentBlockName = (value: string) => {
+    const oldBlockName: string = this.props.stepName;
     let currentCellMetadata = {
-      ...this.state.currentActiveCellMetadata,
+      prevBlockNames: this.props.stepDependencies,
       blockName: value,
     };
-    await this.setState({ currentActiveCellMetadata: currentCellMetadata });
+
     this.setKaleCellTags(
       this.props.notebook,
-      this.props.activeCellIndex,
+      this.context.activeCellIndex,
       KUBEFLOW_CELL_METADATA_KEY,
       currentCellMetadata,
-      true,
-    );
-    this.updateKaleCellTags(this.props.notebook, oldBlockName, value);
+      false,
+    ).then(oldValue => {
+      this.updateKaleCellsTags(this.props.notebook, oldBlockName, value);
+    });
   };
 
-  updatePrevBlocksNames = async (previousBlocks: string[]) => {
+  /**
+   * Even handler of the MultiSelect used to select the dependencies of a block
+   */
+  updatePrevBlocksNames = (previousBlocks: string[]) => {
     let currentCellMetadata = {
-      ...this.state.currentActiveCellMetadata,
+      blockName: this.props.stepName,
       prevBlockNames: previousBlocks,
     };
-    await this.setState({ currentActiveCellMetadata: currentCellMetadata });
+
     this.setKaleCellTags(
       this.props.notebook,
-      this.props.activeCellIndex,
+      this.context.activeCellIndex,
       KUBEFLOW_CELL_METADATA_KEY,
       currentCellMetadata,
       true,
@@ -293,25 +335,27 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
     notebookPanel: NotebookPanel,
     index: number,
     key: string,
-    value: IKaleCellMetadata,
+    metadata: { blockName: string; prevBlockNames: string[] },
     save: boolean,
-  ) => {
+  ): Promise<any> => {
     // make the dict to save to tags
-    let nb = value.blockName;
+    let nb = metadata.blockName;
     // not a reserved name
-    if (!RESERVED_CELL_NAMES.includes(value.blockName)) {
+    if (!RESERVED_CELL_NAMES.includes(metadata.blockName)) {
       nb = 'block:' + nb;
     }
-    const tags = [nb].concat(value.prevBlockNames.map(v => 'prev:' + v));
-    CellUtils.setCellMetaData(notebookPanel, index, 'tags', tags, save);
+    const stepDependencies = metadata.prevBlockNames || [];
+    const tags = [nb].concat(stepDependencies.map(v => 'prev:' + v));
+    return CellUtils.setCellMetaData(notebookPanel, index, 'tags', tags, save);
   };
 
-  updateKaleCellTags = (
+  updateKaleCellsTags = (
     notebookPanel: NotebookPanel,
     oldBlockName: string,
     newBlockName: string,
   ) => {
     let i: number;
+    const allPromises = [];
     for (i = 0; i < notebookPanel.model.cells.length; i++) {
       const tags: string[] = CellUtils.getCellMetaData(
         notebookPanel.content,
@@ -329,121 +373,120 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
           }
         })
         .filter(t => t !== '' && t !== 'prev:');
-      CellUtils.setCellMetaData(notebookPanel, i, 'tags', newTags, false);
+      allPromises.push(
+        CellUtils.setCellMetaData(notebookPanel, i, 'tags', newTags, false),
+      );
     }
-    notebookPanel.context.save();
+    Promise.all(allPromises).then(() => {
+      notebookPanel.context.save();
+    });
   };
-
-  toggleEditor() {
-    this.setState({ showEditor: !this.state.showEditor });
-  }
 
   getColor(name: string) {
     return ColorUtils.getColor(name);
   }
 
+  /**
+   * Function called before updating the value of the block name input text
+   * field. It acts as a validator.
+   */
   onBeforeUpdate = (value: string) => {
-    const stepNameErrorMsg = STEP_NAME_ERROR_MSG;
-    this.setState({ stepNameErrorMsg });
-
+    if (value === this.props.stepName) {
+      return false;
+    }
     const blockNames = this.getAllBlocks(this.props.notebook.content);
     if (blockNames.includes(value)) {
       this.setState({ stepNameErrorMsg: 'This name already exists.' });
       return true;
     }
-
+    this.setState({ stepNameErrorMsg: STEP_NAME_ERROR_MSG });
     return false;
   };
 
-  render() {
-    const previousBlockChoices = this.state.allBlocks
-      .filter(
-        el =>
-          !RESERVED_CELL_NAMES.includes(el) &&
-          !(el === this.state.currentActiveCellMetadata.blockName),
-      )
-      .map(name => ({ value: name, color: `#${this.getColor(name)}` }));
+  getPrevBlockNotice = () => {
+    const prevBlockNotice =
+      this.state.previousBlockName && this.props.stepName === ''
+        ? 'Leave step name empty to merge code to block ' +
+          this.state.previousBlockName
+        : null;
 
-    const cellType = RESERVED_CELL_NAMES.includes(
-      this.state.currentActiveCellMetadata.blockName,
-    )
-      ? this.state.currentActiveCellMetadata.blockName
+    return prevBlockNotice;
+  };
+
+  /**
+   * Event handler of close button, positioned on the top right of the cell
+   */
+  closeEditor() {
+    this.context.onEditorVisibilityChange(false);
+  }
+
+  render() {
+    const cellType = RESERVED_CELL_NAMES.includes(this.props.stepName)
+      ? this.props.stepName
       : 'step';
 
     const cellTypeHelperText =
-      RESERVED_CELL_NAMES_HELP_TEXT[
-        this.state.currentActiveCellMetadata.blockName
-      ] || null;
+      RESERVED_CELL_NAMES_HELP_TEXT[this.props.stepName] || null;
 
-    const prevBlockNotice =
-      this.state.prevBlockName &&
-      this.state.currentActiveCellMetadata.blockName === ''
-        ? 'Leave step name empty to merge code to block ' +
-          this.state.prevBlockName
-        : null;
+    const prevBlockNotice = this.getPrevBlockNotice();
 
     return (
       <React.Fragment>
         <div>
           <div
             className={
-              this.state.wrapperClass +
-              (this.state.showEditor ? ' opened' : '') +
+              'kale-metadata-editor-wrapper' +
+              (this.context.isEditorVisible ? ' opened' : '') +
               (cellType === 'step' ? ' kale-is-step' : '')
             }
             ref={this.editorRef}
           >
-            <button
-              className="kale-editor-toggle"
-              onClick={() => this.toggleEditor()}
-            >
-              {this.state.showEditor ? <CloseIcon /> : <EditIcon />}
-            </button>
             <div
               className={
                 'kale-cell-metadata-editor' +
-                (this.state.showEditor ? '' : ' hidden')
+                (this.context.isEditorVisible ? '' : ' hidden')
               }
             >
-              <div>
-                <MaterialSelect
-                  updateValue={this.updateCurrentCellType}
-                  values={CELL_TYPES}
-                  value={cellType}
-                  label={'Cell type'}
-                  index={0}
-                  variant="standard"
-                  helperText={cellTypeHelperText}
-                />
-
-                {cellType === 'step' ? (
-                  <MaterialInput
-                    label={'Step name'}
-                    updateValue={this.updateCurrentBlockName}
-                    value={this.state.currentActiveCellMetadata.blockName}
-                    regex={'^([_a-z]([_a-z0-9]*)?)?$'}
-                    regexErrorMsg={this.state.stepNameErrorMsg}
-                    helperText={prevBlockNotice}
-                    variant="standard"
-                    onBeforeUpdate={this.onBeforeUpdate}
-                  />
-                ) : (
-                  ''
-                )}
-              </div>
+              <button
+                className="kale-editor-close-btn"
+                onClick={() => this.closeEditor()}
+              >
+                <CloseIcon />
+              </button>
+              <MaterialSelect
+                updateValue={this.updateCurrentCellType}
+                values={CELL_TYPES}
+                value={cellType}
+                label={'Cell type'}
+                index={0}
+                variant="standard"
+                helperText={cellTypeHelperText}
+              />
 
               {cellType === 'step' ? (
-                <div>
-                  <MaterialSelectMulti
-                    disabled={this.props.parentBlockName.length > 0}
-                    updateSelected={this.updatePrevBlocksNames}
-                    options={previousBlockChoices}
-                    variant="standard"
-                    selected={
-                      this.state.currentActiveCellMetadata.prevBlockNames
-                    }
-                  />
-                </div>
+                <MaterialInput
+                  label={'Step name'}
+                  updateValue={this.updateCurrentBlockName}
+                  value={this.props.stepName || ''}
+                  regex={'^([_a-z]([_a-z0-9]*)?)?$'}
+                  regexErrorMsg={this.state.stepNameErrorMsg}
+                  helperText={prevBlockNotice}
+                  variant="standard"
+                  onBeforeUpdate={this.onBeforeUpdate}
+                />
+              ) : (
+                ''
+              )}
+              {cellType === 'step' ? (
+                <MaterialSelectMulti
+                  disabled={
+                    !(this.props.stepName && this.props.stepName.length > 0)
+                  }
+                  updateSelected={this.updatePrevBlocksNames}
+                  options={this.state.blockDependenciesChoices}
+                  variant="standard"
+                  selected={this.props.stepDependencies || []}
+                />
               ) : (
                 ''
               )}

--- a/src/components/cell-metadata/InlineCellMetadata.tsx
+++ b/src/components/cell-metadata/InlineCellMetadata.tsx
@@ -245,8 +245,8 @@ export class InlineCellsMetadata extends React.Component<IProps, IState> {
           />
         </div>
         <div className="hidden">
-          {this.state.metadataCmp}
           {this.state.editorsCmp}
+          {this.state.metadataCmp}
         </div>
       </React.Fragment>
     );

--- a/src/components/cell-metadata/InlineCellMetadata.tsx
+++ b/src/components/cell-metadata/InlineCellMetadata.tsx
@@ -24,10 +24,10 @@ import {
 import { isCodeCellModel, CodeCellModel, ICellModel } from '@jupyterlab/cells';
 import Switch from 'react-switch';
 import CellUtils from '../../utils/CellUtils';
+import TagsUtils from '../../utils/TagsUtils';
 import { InlineMetadata } from './InlineMetadata';
 import {
   CellMetadataEditor,
-  RESERVED_CELL_NAMES,
   IProps as EditorProps,
 } from './CellMetadataEditor';
 import { CellMetadataContext } from './CellMetadataContext';
@@ -198,7 +198,7 @@ export class InlineCellsMetadata extends React.Component<IProps, IState> {
         continue;
       }
 
-      let tags = this.getKaleCellTags(this.props.notebook.content, index);
+      let tags = TagsUtils.getKaleCellTags(this.props.notebook.content, index);
       if (!tags) {
         tags = {
           blockName: '',
@@ -209,7 +209,7 @@ export class InlineCellsMetadata extends React.Component<IProps, IState> {
       let previousBlockName = '';
 
       if (!tags.blockName) {
-        previousBlockName = this.getPreviousBlock(
+        previousBlockName = TagsUtils.getPreviousBlock(
           this.props.notebook.content,
           index,
         );
@@ -245,59 +245,6 @@ export class InlineCellsMetadata extends React.Component<IProps, IState> {
         callback();
       }
     });
-  };
-
-  getAllBlocks = (notebook: Notebook): string[] => {
-    let blocks = new Set<string>();
-    for (const idx of Array(notebook.model.cells.length).keys()) {
-      let mt = this.getKaleCellTags(notebook, idx);
-      if (mt && mt.blockName && mt.blockName !== '') {
-        blocks.add(mt.blockName);
-      }
-    }
-    return Array.from(blocks);
-  };
-
-  getPreviousBlock = (notebook: Notebook, current: number): string => {
-    for (let i = current - 1; i >= 0; i--) {
-      let mt = this.getKaleCellTags(notebook, i);
-      if (
-        mt &&
-        mt.blockName &&
-        mt.blockName !== 'skip' &&
-        mt.blockName !== ''
-      ) {
-        return mt.blockName;
-      }
-    }
-    return null;
-  };
-
-  getKaleCellTags = (notebook: Notebook, index: number) => {
-    const tags: string[] = CellUtils.getCellMetaData(notebook, index, 'tags');
-    if (tags) {
-      let b_name = tags.map(v => {
-        if (RESERVED_CELL_NAMES.includes(v)) {
-          return v;
-        }
-        if (v.startsWith('block:')) {
-          return v.replace('block:', '');
-        }
-      });
-
-      let prevs = tags
-        .filter(v => {
-          return v.startsWith('prev:');
-        })
-        .map(v => {
-          return v.replace('prev:', '');
-        });
-      return {
-        blockName: b_name[0],
-        prevBlockNames: prevs,
-      };
-    }
-    return null;
   };
 
   handleChange(checked: boolean) {

--- a/src/components/cell-metadata/InlineMetadata.tsx
+++ b/src/components/cell-metadata/InlineMetadata.tsx
@@ -22,164 +22,184 @@ import {
   RESERVED_CELL_NAMES_HELP_TEXT,
 } from './CellMetadataEditor';
 
-interface InlineMetadata {
+interface IProps {
   blockName: string;
   parentBlockName: string;
-  prevBlockNames?: string[];
+  prevBlockNames: string[];
   cellElement: any;
 }
 
-let inlineMetadataIndex = 0;
+interface IState {
+  defaultCSSClasses: string;
+  className: string;
+  cellTypeClass: string;
+  color: string;
+  dependencies: any[];
+}
 
-export const InlineMetadata: React.FunctionComponent<InlineMetadata> = props => {
-  let wrapperRef: HTMLElement = null;
-  const imIndex = inlineMetadataIndex++;
-  const defaultCSSClasses = `kale-inline-cell-metadata kale-inline-cell-metadata-${imIndex}`;
-  const [className, setClassName] = React.useState(defaultCSSClasses);
-  const [dependencies, setDependencies] = React.useState([]);
-  const [color, setColor] = React.useState('');
-  const [cellTypeClass, setCellTypeClass] = React.useState('');
+const DefaultState: IState = {
+  defaultCSSClasses: `kale-inline-cell-metadata`,
+  className: `kale-inline-cell-metadata`,
+  cellTypeClass: '',
+  color: '',
+  dependencies: [],
+};
 
-  React.useEffect(() => {
-    updateClassName();
-    checkIfReservedName();
-    updateStyles();
-    updateDependencies();
-    moveElement();
-  }, [
-    props.blockName,
-    props.parentBlockName,
-    props.prevBlockNames,
-    props.cellElement,
-  ]);
+export class InlineMetadata extends React.Component<IProps, IState> {
+  wrapperRef: React.RefObject<HTMLDivElement> = null;
+  state = DefaultState;
 
-  React.useEffect(() => {
-    return () => {
-      // Cleanup
-      const cellElement = props.cellElement;
-      cellElement.classList.remove('kale-merged-cell');
+  constructor(props: IProps) {
+    super(props);
+    this.wrapperRef = React.createRef();
+  }
 
-      const codeMirrorElem = cellElement.querySelector('.CodeMirror');
-      if (codeMirrorElem) {
-        codeMirrorElem.style.border = '';
-      }
+  componentDidMount() {
+    this.updateClassName();
+    this.checkIfReservedName();
+    this.updateStyles();
+    this.updateDependencies();
+    this.moveElement();
+  }
 
-      if (wrapperRef) {
-        wrapperRef.remove();
-      }
-    };
-  }, []);
+  componentWillUnmount() {
+    const cellElement = this.props.cellElement;
+    cellElement.classList.remove('kale-merged-cell');
 
-  const updateClassName = () => {
-    let c = defaultCSSClasses;
-    if (props.parentBlockName) {
+    const codeMirrorElem = cellElement.querySelector('.CodeMirror');
+    if (codeMirrorElem) {
+      codeMirrorElem.style.border = '';
+    }
+
+    if (this.wrapperRef) {
+      this.wrapperRef.current.remove();
+    }
+  }
+
+  componentDidUpdate(prevProps: Readonly<IProps>, prevState: Readonly<IState>) {
+    if (
+      prevProps.blockName !== this.props.blockName ||
+      prevProps.parentBlockName !== this.props.parentBlockName ||
+      prevProps.prevBlockNames !== this.props.prevBlockNames ||
+      prevProps.cellElement !== this.props.cellElement
+    ) {
+      this.updateClassName();
+      this.checkIfReservedName();
+      this.updateStyles();
+      this.updateDependencies();
+    }
+  }
+
+  updateClassName() {
+    let c = this.state.defaultCSSClasses;
+    if (this.props.parentBlockName) {
       c = c + ' hidden';
     }
-    setClassName(c);
-  };
+    this.setState({ className: c });
+  }
 
-  const updateStyles = () => {
-    const name = props.blockName || props.parentBlockName;
+  checkIfReservedName() {
+    let cellTypeClass = '';
+    if (RESERVED_CELL_NAMES.includes(this.props.blockName)) {
+      cellTypeClass = 'kale-reserved-cell';
+    }
+    this.setState({ cellTypeClass });
+  }
+
+  updateStyles() {
+    const name = this.props.blockName || this.props.parentBlockName;
     if (!name) {
       return;
     }
-    const rgb = getColorFromName(name);
-    setColor(rgb);
+    const rgb = this.getColorFromName(name);
+    this.setState({ color: rgb });
 
-    const cellElement = props.cellElement;
+    const cellElement = this.props.cellElement;
 
     const codeMirrorElem = cellElement.querySelector(
       '.CodeMirror',
     ) as HTMLElement;
     if (codeMirrorElem) {
-      codeMirrorElem.style.border = `2px solid #${rgb}`;
+      codeMirrorElem.style.border = `1px solid #${rgb}`;
     }
-    if (props.parentBlockName) {
+    if (this.props.parentBlockName) {
       cellElement.classList.add('kale-merged-cell');
     }
-  };
+  }
 
-  const updateDependencies = () => {
-    setDependencies(
-      props.prevBlockNames.map((name, i) => {
-        const rgb = getColorFromName(name);
-        return (
-          <Tooltip placement="top" key={i} title={name}>
-            <div
-              className="kale-inline-cell-dependency"
-              style={{
-                backgroundColor: `#${rgb}`,
-              }}
-            ></div>
-          </Tooltip>
-        );
-      }),
-    );
-  };
-
-  const checkIfReservedName = () => {
-    if (RESERVED_CELL_NAMES.includes(props.blockName)) {
-      setCellTypeClass('kale-reserved-cell');
-    } else {
-      setCellTypeClass('');
-    }
-  };
-
-  const moveElement = () => {
-    if (
-      (props.blockName || props.parentBlockName) &&
-      wrapperRef &&
-      !wrapperRef.classList.contains('moved')
-    ) {
-      wrapperRef.classList.add('moved');
-      props.cellElement.insertAdjacentElement('afterbegin', wrapperRef);
-    }
-  };
-
-  const getColorFromName = (name: string) => {
+  getColorFromName(name: string) {
     return ColorUtils.getColor(name);
-  };
+  }
 
-  return (
-    <div>
-      <div
-        className={className}
-        ref={elem => {
-          if (elem) wrapperRef = elem;
-        }}
-      >
-        {/* Add a `step: ` string before the Chip in case the chip belongs to a pipeline step*/}
-        {RESERVED_CELL_NAMES.includes(props.blockName) ? (
-          ''
-        ) : (
-          <p style={{ fontStyle: 'italic', marginRight: '5px' }}>step: </p>
-        )}
-
-        <Tooltip
-          placement="top"
-          key={props.blockName + 'tooltip'}
-          title={
-            RESERVED_CELL_NAMES.includes(props.blockName)
-              ? RESERVED_CELL_NAMES_HELP_TEXT[props.blockName]
-              : 'This cell starts the pipeline step: ' + props.blockName
-          }
-        >
-          <Chip
-            className={`kale-chip ${cellTypeClass}`}
-            style={{ backgroundColor: `#${color}` }}
-            key={props.blockName}
-            label={props.blockName}
-          />
+  updateDependencies() {
+    const dependencies = this.props.prevBlockNames.map((name, i) => {
+      const rgb = this.getColorFromName(name);
+      return (
+        <Tooltip placement="top" key={i} title={name}>
+          <div
+            className="kale-inline-cell-dependency"
+            style={{
+              backgroundColor: `#${rgb}`,
+            }}
+          ></div>
         </Tooltip>
+      );
+    });
+    this.setState({ dependencies });
+  }
 
-        {/* Add a `depends on: ` string before the deps dots in case there are some*/}
-        {dependencies.length > 0 ? (
-          <p style={{ fontStyle: 'italic', margin: '0 5px' }}>depends on: </p>
-        ) : (
-          ''
-        )}
-        {dependencies}
+  moveElement() {
+    // FIXME:  need moved class??
+    if (
+      (this.props.blockName || this.props.parentBlockName) &&
+      this.wrapperRef &&
+      !this.wrapperRef.current.classList.contains('moved')
+    ) {
+      this.wrapperRef.current.classList.add('moved');
+      this.props.cellElement.insertAdjacentElement(
+        'afterbegin',
+        this.wrapperRef.current,
+      );
+    }
+  }
+
+  render() {
+    return (
+      <div>
+        <div className={this.state.className} ref={this.wrapperRef}>
+          {/* Add a `step: ` string before the Chip in case the chip belongs to a pipeline step*/}
+          {RESERVED_CELL_NAMES.includes(this.props.blockName) ? (
+            ''
+          ) : (
+            <p style={{ fontStyle: 'italic', marginRight: '5px' }}>step: </p>
+          )}
+
+          <Tooltip
+            placement="top"
+            key={this.props.blockName + 'tooltip'}
+            title={
+              RESERVED_CELL_NAMES.includes(this.props.blockName)
+                ? RESERVED_CELL_NAMES_HELP_TEXT[this.props.blockName]
+                : 'This cell starts the pipeline step: ' + this.props.blockName
+            }
+          >
+            <Chip
+              className={`kale-chip ${this.state.cellTypeClass}`}
+              style={{ backgroundColor: `#${this.state.color}` }}
+              key={this.props.blockName}
+              label={this.props.blockName}
+            />
+          </Tooltip>
+
+          {/* Add a `depends on: ` string before the deps dots in case there are some*/}
+          {this.state.dependencies.length > 0 ? (
+            <p style={{ fontStyle: 'italic', margin: '0 5px' }}>depends on: </p>
+          ) : (
+            ''
+          )}
+          {this.state.dependencies}
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+}

--- a/src/utils/CellUtils.ts
+++ b/src/utils/CellUtils.ts
@@ -105,7 +105,7 @@ export default class CellUtilities {
     key: string,
     value: any,
     save: boolean = false,
-  ): any {
+  ): Promise<any> {
     if (!notebookPanel) {
       throw new Error('Notebook was null!');
     }
@@ -116,11 +116,11 @@ export default class CellUtilities {
       const cell: ICellModel = notebookPanel.model.cells.get(index);
       const oldVal: any = cell.metadata.set(key, value);
       if (save) {
-        notebookPanel.context.save();
+        return notebookPanel.context.save();
       }
-      return oldVal;
+      return Promise.resolve(oldVal);
     } catch (error) {
-      throw error;
+      return Promise.reject(error);
     }
   }
 

--- a/src/utils/TagsUtils.ts
+++ b/src/utils/TagsUtils.ts
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2020 The Kale Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Notebook, NotebookPanel } from '@jupyterlab/notebook';
+import CellUtils from './CellUtils';
+import { RESERVED_CELL_NAMES } from '../components/cell-metadata/CellMetadataEditor';
+
+interface IKaleCellTags {
+  blockName: string;
+  prevBlockNames: string[];
+}
+
+/** Contains utility functions for manipulating/handling Kale cell tags. */
+export default class TagsUtils {
+  /**
+   * Get all the `block:<name>` tags in the notebook.
+   * @param notebook Notebook object
+   * @returns Array<str> - a list of the block names (i.e. the pipeline steps'
+   *  names)
+   */
+  public static getAllBlocks(notebook: Notebook): string[] {
+    if (!notebook.model) {
+      return [];
+    }
+    let blocks = new Set<string>();
+    // iterate through the notebook cells
+    for (const idx of Array(notebook.model.cells.length).keys()) {
+      // get the tags of the current cell
+      let mt = this.getKaleCellTags(notebook, idx);
+      if (mt && mt.blockName && mt.blockName !== '') {
+        blocks.add(mt.blockName);
+      }
+    }
+    return Array.from(blocks);
+  }
+
+  /**
+   * Given a notebook cell index, get the closest previous cell that has a Kale
+   * tag
+   * @param notebook The notebook object
+   * @param current The index of the cell to start the search from
+   * @returns string - Name of the `block` tag of the closest previous cell
+   */
+  public static getPreviousBlock(notebook: Notebook, current: number): string {
+    for (let i = current - 1; i >= 0; i--) {
+      let mt = this.getKaleCellTags(notebook, i);
+      if (
+        mt &&
+        mt.blockName &&
+        mt.blockName !== 'skip' &&
+        mt.blockName !== ''
+      ) {
+        return mt.blockName;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Parse a notebook cell's metadata and return all the Kale tags
+   * @param notebook Notebook object
+   * @param index The index of the notebook cell
+   * @returns IKaleCellTags: an object containing all the cell's Kale tags
+   */
+  public static getKaleCellTags(
+    notebook: Notebook,
+    index: number,
+  ): IKaleCellTags {
+    const tags: string[] = CellUtils.getCellMetaData(notebook, index, 'tags');
+    if (tags) {
+      let b_name = tags.map(v => {
+        if (RESERVED_CELL_NAMES.includes(v)) {
+          return v;
+        }
+        if (v.startsWith('block:')) {
+          return v.replace('block:', '');
+        }
+      });
+
+      let prevs = tags
+        .filter(v => {
+          return v.startsWith('prev:');
+        })
+        .map(v => {
+          return v.replace('prev:', '');
+        });
+      return {
+        blockName: b_name[0],
+        prevBlockNames: prevs,
+      };
+    }
+    return null;
+  }
+
+  /**
+   * Set the provided Kale metadata into the specified notebook cell
+   * @param notebookPanel NotebookPanel object
+   * @param index index of the target cell
+   * @param metadata Kale metadata
+   * @param save True to save the notebook after the operation
+   */
+  public static setKaleCellTags(
+    notebookPanel: NotebookPanel,
+    index: number,
+    metadata: IKaleCellTags,
+    save: boolean,
+  ): Promise<any> {
+    // make the dict to save to tags
+    let nb = metadata.blockName;
+    // not a reserved name
+    if (!RESERVED_CELL_NAMES.includes(metadata.blockName)) {
+      nb = 'block:' + nb;
+    }
+    const stepDependencies = metadata.prevBlockNames || [];
+    const tags = [nb].concat(stepDependencies.map(v => 'prev:' + v));
+    return CellUtils.setCellMetaData(notebookPanel, index, 'tags', tags, save);
+  }
+
+  /**
+   * Parse the entire notebook cells to change a block name. This happens when
+   * the block name of a cell is changed by the user, using Kale's inline tag
+   * editor. We need to parse the entire notebook because all the `prev` dependencies
+   * specified in the cells must be bound to the new name.
+   * @param notebookPanel NotebookPanel object
+   * @param oldBlockName previous block name
+   * @param newBlockName new block name
+   */
+  public static updateKaleCellsTags(
+    notebookPanel: NotebookPanel,
+    oldBlockName: string,
+    newBlockName: string,
+  ) {
+    let i: number;
+    const allPromises = [];
+    for (i = 0; i < notebookPanel.model.cells.length; i++) {
+      const tags: string[] = CellUtils.getCellMetaData(
+        notebookPanel.content,
+        i,
+        'tags',
+      );
+      // If there is a prev tag that points to the old name, update it with the
+      // new one.
+      let newTags: string[] = (tags || [])
+        .map(t => {
+          if (t === 'prev:' + oldBlockName) {
+            return RESERVED_CELL_NAMES.includes(newBlockName)
+              ? ''
+              : 'prev:' + newBlockName;
+          } else {
+            return t;
+          }
+        })
+        .filter(t => t !== '' && t !== 'prev:');
+      allPromises.push(
+        CellUtils.setCellMetaData(notebookPanel, i, 'tags', newTags, false),
+      );
+    }
+    Promise.all(allPromises).then(() => {
+      notebookPanel.context.save();
+    });
+  }
+
+  /**
+   * Clean up the Kale tags from a cell. After cleaning the cell, loop though
+   * the notebook to remove all occurrences of the deleted block name.
+   * @param notebook NotebookPanel object
+   * @param activeCellIndex The active cell index
+   * @param stepName The old name of the active cell to be cleaned.
+   */
+  public static resetCell(
+    notebook: NotebookPanel,
+    activeCellIndex: number,
+    stepName: string,
+  ) {
+    const value = '';
+    const previousBlocks: string[] = [];
+
+    const oldBlockName: string = stepName;
+    let cellMedatada = {
+      prevBlockNames: previousBlocks,
+      blockName: value,
+    };
+    TagsUtils.setKaleCellTags(
+      notebook,
+      activeCellIndex,
+      cellMedatada,
+      false,
+    ).then(oldValue => {
+      TagsUtils.updateKaleCellsTags(notebook, oldBlockName, value);
+    });
+  }
+}

--- a/style/index.css
+++ b/style/index.css
@@ -379,7 +379,7 @@ a {
   /* FIXME: find a way to calculate margin */
   margin-left: 73px;
   margin-top: 8px;
-  margin-bottom: 2px;
+  margin-bottom: 4px;
   display: flex;
   align-items: center;
 }
@@ -401,6 +401,7 @@ a {
   position: relative;
 }
 
+.kale-editor-close-btn,
 .kale-editor-toggle {
   border: 0;
   width: 16px;
@@ -414,36 +415,32 @@ a {
   color: var(--jp-inverse-layout-color3);
 }
 
+.kale-editor-close-btn > svg,
 .kale-editor-toggle > svg {
   width: 100%;
   height: auto;
+}
+
+.kale-editor-toggle > svg {
   background-color: var(--jp-cell-editor-background);
 }
 
-.jp-Notebook .jp-Cell.jp-mod-selected .kale-editor-toggle > svg {
+.jp-Notebook.jp-mod-editMode
+  .jp-Cell.jp-mod-selected
+  .kale-editor-toggle
+  > svg {
   background-color: #fff;
 }
 
 .kale-cell-metadata-editor {
   margin-bottom: 6px;
   display: flex;
-  width: 50%;
   border: 1px solid var(--md-grey-400);
-  padding: 6px;
 }
 
-.kale-cell-metadata-editor > div {
-  width: 50%;
-}
-
-.kale-cell-metadata-editor > div:first-child {
+.kale-cell-metadata-editor > .MuiFormControl-root {
+  margin-left: 4px;
   margin-right: 4px;
-  border-right: 1px solid var(--md-grey-400);
-  padding-right: 6px;
-}
-
-.kale-cell-metadata-editor .MuiSelect-selectMenu {
-  min-height: 25px;
 }
 
 .kale-metadata-editor-wrapper.opened .kale-editor-toggle {
@@ -467,8 +464,15 @@ a {
 }
 
 .kale-chip.MuiChip-root {
-  height: 21px;
+  height: 19px;
   color: #fff;
+}
+
+.kale-chip-select.MuiChip-root {
+  height: 18px;
+  margin-right: 1px;
+  margin-bottom: 1px;
+  line-height: 18px;
 }
 
 .kale-metadata-editor-wrapper:not(.kale-is-step)


### PR DESCRIPTION
In this pull request, all metadata related components (`InlineCellMetadata`, `InlineMetadata`, `CellMetadataEditor`) have been revamped. Some of the big changes are:

- The editor is now only one instance which significantly improves the UX.
- Minor style changes in the editor and in the cell's border.
- Better support when a user adds/removes cells or changes the cell's type.
- Various bug fixes in the editor's form.