### PR TITLE
Improve color generation for step names

### DIFF
--- a/src/components/cell-metadata/ColorUtils.ts
+++ b/src/components/cell-metadata/ColorUtils.ts
@@ -36,9 +36,10 @@ export default class ColorUtils {
   }
 
   public static hashString(str: string): number {
-    // http://erlycoder.com/49/javascript-hash-functions-to-convert-string-into-integer-hash-
-    // #a9a9a9  skip
-    // #008000  imports
+    // Append a random string in in order to prevent generation for similar
+    // hashes from similar strings which will cause nearly identical colors in
+    // UI
+    str = str + 'pz8';
     let hash = 0;
     for (let i = 0; i < str.length; i++) {
       const char = str.charCodeAt(i);


### PR DESCRIPTION
Update the hashString() method in ColorUtils class which will result
in a better color generation for similar step names.

Signed-off-by: Tasos Alexiou <tasos@arrikto.com>